### PR TITLE
‘各htmlファイルのinclude調整など’

### DIFF
--- a/django/static/admin/js/activity_list.js
+++ b/django/static/admin/js/activity_list.js
@@ -84,30 +84,3 @@ async function fetchActivityRecords() {
  // データを返す
  return data;
 }
-
-// 非同期処理を実行し、チャットアイテムをロード
-loadChatItems();
-
-// モーダルの表示を制御する関数
-function showModal() {
- const modalBg = document.getElementById("modal-bg");
- modalBg.classList.remove("hidden");
- modalBg.classList.add("flex");
-}
-
-// DOMが読み込まれた後に実行されるように設定
-document.addEventListener("DOMContentLoaded", function () {
- // 省略: メニューボタン、モバイルメニュー、閉じるボタンの定義とイベントリスナー
-
- // 閉じるボタンがクリックされた時の処理
- closeButton.addEventListener("click", function () {
-  mobileMenu.classList.add("hidden");
- });
-
- // 閉じるボタンをクリックした際のイベントリスナー
- document.getElementById("close-modal").addEventListener("click", function () {
-  const modalBg = document.getElementById("modal-bg");
-  modalBg.classList.remove("flex");
-  modalBg.classList.add("hidden");
- });
-});

--- a/django/static/admin/js/home.js
+++ b/django/static/admin/js/home.js
@@ -1,28 +1,3 @@
-// DOMが読み込まれた後に実行されるように設定
-document.addEventListener("DOMContentLoaded", function () {
- // ハンバーガーメニューボタン（画像）を取得
- const menuButton = document.querySelector(".hamburger-menu");
- // モバイルメニューを取得
- const mobileMenu = document.getElementById("mobileMenu");
- // 閉じるボタンを取得
- const closeButton = document.getElementById("closeMenuButton");
-
- // メニューボタンがクリックされた時の処理
- menuButton.addEventListener("click", function () {
-  mobileMenu.classList.toggle("hidden");
- });
-
- // 閉じるボタンがクリックされた時の処理
- closeButton.addEventListener("click", function () {
-  mobileMenu.classList.add("hidden");
- });
-
- //  モバイルメニューの背景部分がクリックされた時の処理を実装したかったがZindexの関係かうまくいかなかった。
- //  mobileMenuBackground.addEventListener("click", function () {
- //   mobileMenu.classList.add("hidden");
- //  });
-});
-
 // Ajax を使って views.py の get_total_days 関数を呼び出す
 $.ajax({
  url: '{% url "get_total_days" %}',

--- a/django/static/admin/js/menu_modal.js
+++ b/django/static/admin/js/menu_modal.js
@@ -1,0 +1,24 @@
+// DOMが読み込まれた後に実行されるように設定
+document.addEventListener("DOMContentLoaded", function () {
+ // ハンバーガーメニューボタン（画像）を取得
+ const menuButton = document.querySelector(".hamburger-menu");
+ // モバイルメニューを取得
+ const mobileMenu = document.getElementById("mobileMenu");
+ // 閉じるボタンを取得
+ const closeButton = document.getElementById("closeMenuButton");
+
+ // メニューボタンがクリックされた時の処理
+ menuButton.addEventListener("click", function () {
+  mobileMenu.classList.toggle("hidden");
+ });
+
+ // 閉じるボタンがクリックされた時の処理
+ closeButton.addEventListener("click", function () {
+  mobileMenu.classList.add("hidden");
+ });
+
+ //  モバイルメニューの背景部分がクリックされた時の処理を実装したかったがZindexの関係かうまくいかなかった。
+ //  mobileMenuBackground.addEventListener("click", function () {
+ //   mobileMenu.classList.add("hidden");
+ //  });
+});

--- a/django/staticfiles/admin/js/category_add.js
+++ b/django/staticfiles/admin/js/category_add.js
@@ -1,0 +1,16 @@
+// 'copyToClipboard' という名前の関数を定義します。const を使用することで、この関数は再代入できません。
+// 'text' という引数を受け取り、このテキストをクリップボードにコピーします。
+const copyToClipboard = async text => {
+ try {
+  // 'navigator.clipboard.writeText' 関数は、与えられたテキストをクリップボードに書き込むための非同期関数です。
+  // 'await' キーワードを使用して、この非同期操作が完了するのを待ちます。
+  await navigator.clipboard.writeText(text);
+
+  // クリップボードへのコピーが成功したら、アラートを表示してユーザーに通知します。
+  alert("Copied color code: " + text);
+ } catch (err) {
+  // もし何らかの理由でクリップボードへのコピーが失敗した場合（例えば、ブラウザが対応していない場合など）は、
+  // エラーメッセージをコンソールに出力します。これは開発者が問題をデバッグするのに役立ちます。
+  console.error("Failed to copy text: ", err);
+ }
+};

--- a/django/staticfiles/admin/js/menu_modal.js
+++ b/django/staticfiles/admin/js/menu_modal.js
@@ -1,0 +1,24 @@
+// DOMが読み込まれた後に実行されるように設定
+document.addEventListener("DOMContentLoaded", function () {
+ // ハンバーガーメニューボタン（画像）を取得
+ const menuButton = document.querySelector(".hamburger-menu");
+ // モバイルメニューを取得
+ const mobileMenu = document.getElementById("mobileMenu");
+ // 閉じるボタンを取得
+ const closeButton = document.getElementById("closeMenuButton");
+
+ // メニューボタンがクリックされた時の処理
+ menuButton.addEventListener("click", function () {
+  mobileMenu.classList.toggle("hidden");
+ });
+
+ // 閉じるボタンがクリックされた時の処理
+ closeButton.addEventListener("click", function () {
+  mobileMenu.classList.add("hidden");
+ });
+
+ //  モバイルメニューの背景部分がクリックされた時の処理を実装したかったがZindexの関係かうまくいかなかった。
+ //  mobileMenuBackground.addEventListener("click", function () {
+ //   mobileMenu.classList.add("hidden");
+ //  });
+});

--- a/django/templates/activity_add.html
+++ b/django/templates/activity_add.html
@@ -4,120 +4,32 @@
 bg-snow text-textBlack font-NotoSans
 {% endblock body_class %}
 
+{% block title %}
+<title>アクティビティ追加</title>
+{% endblock %}
+
 {% load static %}
+
 {% block content %}
 
-<!-- ナビゲーションバーを作成 lgは1024pxからのサイズ-->
-<header class="bg-blackGreen w-full fixed top-0 left-0 h-10 lg:h-20 z-10">
-  <div class="container mx-auto px-4 h-full">
-   <nav class="flex items-center justify-between h-full">
-    <div class="flex items-center">
-     <a href="{% url 'activity:home' %}" class="transform hover:scale-105 transition duration-300">
-      <img
-       src="{% static 'admin/img/kotukotu_thumbnail.png' %}"
-       alt="サムネイルのカメの画像"
-       class="h-10 lg:h-20 w-auto py-1 object-cover rounded-xl"
-      />
-     </a>
-    </div>
-    <div class="flex items-center">
-     <ul class="hidden md:flex space-x-8 text-white">
-      <li>
-        <a href="{% url 'activity:home' %}" class="hover:underline">ホーム</a>
-      </li>
-      <li>
-       <a href="{% url 'activity:activity_list' %}" class="hover:underline">レコード</a>
-      </li>
-      <li>
-       <a href="{% url 'activity:activity_add' %}" class="hover:underline">入力</a>
-      </li>
-      <li>
-       <a href="{% url 'categories:category_add' %}" class="hover:underline">カテゴリー</a>
-      </li>
-     </ul>
-     <button
-      type="submit"
-      class="bg-white text-blackGreen px-4 py-1 rounded-full ml-4 hidden md:block"
-      onclick="window.location.href='{% url 'users:logout' %}'"
-     >
-      ログアウト
-     </button>
-     <!-- ハンバーガーメニューアイコン（横幅760px以下で表示） -->
-     <button class="md:hidden text-white focus:outline-none" aria-label="メニュー">
-      <!-- 画像を埋め込む -->
-      <img
-       src="{% static 'admin/img/hamburgur.png' %}"
-       alt="ハンバーガーメニュー"
-       class="hamburger-menu md:hidden"
-       style="height: 40px; width: auto; object-fit: contain; float: left"
-      />
-     </button>
-    </div>
-   </nav>
-  </div>
- </header>
-
-
- <!-- モバイルメニュー（横幅760px以下でハンバーガーメニューを押したら表示） -->
- <div
-  id="mobileMenu"
-  class="hidden fixed top-0 right-0 w-1/2 h-full z-20 bg-blackGreen bg-opacity-80 md:hidden"
- >
-  <!-- 閉じるボタン -->
-  <img
-   id="closeMenuButton"
-   src="{% static 'admin/img/close_button.png' %}"
-   alt="閉じるボタン"
-   class="absolute top-11 right-2 h-6 w-auto cursor-pointer z-30"
-  />
-
-  <!-- メニューのコンテンツが含まれるコンテナ -->
-  <div class="container mx-auto px-4 h-full flex flex-col justify-center items-center z-30">
-   <!-- メニューのリスト -->
-   <ul class="text-white text-center space-y-4">
-    <li>
-     <a href="{% url 'activity:home' %}" class="hover:underline">ホーム</a>
-    </li>
-    <li>
-     <a href="{% url 'activity:activity_list' %}" class="hover:underline">レコード</a>
-    </li>
-    <li>
-     <a href="{% url 'activity:activity_add' %}" class="hover:underline">入力画面</a>
-    </li>
-    <li>
-     <a href="{% url 'categories:category_add' %}" class="hover:underline">カテゴリー</a>
-    </li>
-    <li>
-     <button type="submit" class="bg-white text-blackGreen px-4 py-1 rounded-full mt-4"
-     onclick="window.location.href='{% url 'users:logout' %}'"
-     >
-      ログアウト
-     </button>
-    </li>
-   </ul>
-  </div>
- </div>
-
+<script src="{% static 'admin/js/activity_add.js' %}"></script>
 
  <!-- 左上のホーム＞のやつを作成 -->
  <div class="container mx-auto px-4 pt-20 text-textBlack">
   <nav class="text-lg">
    <a href="{% url 'activity:home' %}" class="hover:underline text-#474747">ホーム</a>
    <span> &gt; </span>
-   <span>入力画面</span>
+   <span>アクティビティ追加</span>
   </nav>
  </div>
 
 
 <!-- タイトルの作成 -->
 <h1 class="container mx-auto px-4 pt-4 text-center bg-snow text-xl md:text-3xl text-textBlack">
-  積み上げを入力する
+  アクティビティを追加する
  </h1>
  <hr class="mx-10 my-4 border-2 border-blackGreen shadow-md" />
 
-
-
-{% comment %} 上は共通部分。下が調整必要。 {% endcomment %}
 
 <!-- 入力フォーム3つを囲むのコンテナ。小さくなった時の文字の消失はまた後日訂正 -->
 <div class="container mx-auto px-4 py-10">
@@ -208,34 +120,12 @@ bg-snow text-textBlack font-NotoSans
  </div>
 
 
-{% comment %} ここからが元々あった分。完了したものからコメントアウト {% endcomment %}
-  {% comment %} <h1>積み上げ追加</h1>
-  <form id="activityRecordForm" method="post" class="activityRecordForm" onsubmit="event.preventDefault(); submitForm();">
-    {% csrf_token %}
-    {{ form.as_p }}
-    <button type="submit">保存</button>
-
-
-    <a href="{% url 'activity:activity_list' %}">キャンセル</a>
-    <a href="{% url 'activity:home' %}">ホーム画面</a>
-  </form> {% endcomment %}
-
-  {# Modal #}
-  {% comment %} <div id="successModal" style="display: none;">
-    <h5>Good job!</h5>
-    <p id="totalDays">活動累計日数: 0</p>
-    <button id="homeButton">ホームへ</button>
-    <button id="recordButton">レコードへ</button>
-  </div> {% endcomment %}
-
   {# Error messages #}
   <div id="errorMessages" style="display: none;">
     <ul id="errorMessageList">
     </ul>
   </div>
 
-  <script src="{% static 'admin/js/activity_add.js' %}"></script>
-  <script src="{% static 'admin/js/home.js' %}"></script>
 
 {% comment %}
 <script>

--- a/django/templates/activity_list.html
+++ b/django/templates/activity_list.html
@@ -4,6 +4,10 @@
 bg-snow text-textBlack font-NotoSans
 {% endblock body_class %}
 
+{% block title %}
+<title>アクティビティリスト</title>
+{% endblock %}
+
 {% comment %} レコードに当てはめるためのcss {% endcomment %}
 {% block extra_styles %}
 <style>
@@ -63,122 +67,33 @@ bg-snow text-textBlack font-NotoSans
 </style>
 {% endblock %}
 
-
 {% load time_filters %} {# ここでtime_filtersをロードします #}
 
 {% load static %}
 
-
-
-
 {% block content %}
 
+ 
+ {% comment %} APIエンドポイントをジャバスクリプトで使用するため {% endcomment %}
+ <script>
+  const apiUrl = "{% url 'activity:activity_list' %}";
+</script>
+  <script src="{% static 'admin/js/activity_list.js' %}"></script>
 
-<!-- ナビゲーションバーを作成 lgは1024pxからのサイズ-->
-<header class="bg-blackGreen w-full fixed top-0 left-0 h-10 lg:h-20 z-10">
-  <div class="container mx-auto px-4 h-full">
-   <nav class="flex items-center justify-between h-full">
-    <div class="flex items-center">
-     <a href="{% url 'activity:home' %}" class="transform hover:scale-105 transition duration-300">
-      <img
-       src="{% static 'admin/img/kotukotu_thumbnail.png' %}"
-       alt="サムネイルのカメの画像"
-       class="h-10 lg:h-20 w-auto py-1 object-cover rounded-xl"
-      />
-     </a>
-    </div>
-    <div class="flex items-center">
-     <ul class="hidden md:flex space-x-8 text-white">
-      <li>
-        <a href="{% url 'activity:home' %}" class="hover:underline">ホーム</a>
-      </li>
-      <li>
-       <a href="{% url 'activity:activity_list' %}" class="hover:underline">レコード</a>
-      </li>
-      <li>
-       <a href="{% url 'activity:activity_add' %}" class="hover:underline">入力</a>
-      </li>
-      <li>
-       <a href="{% url 'categories:category_add' %}" class="hover:underline">カテゴリー</a>
-      </li>
-     </ul>
-     <button
-      type="submit"
-      class="bg-white text-blackGreen px-4 py-1 rounded-full ml-4 hidden md:block"
-      onclick="window.location.href='{% url 'users:logout' %}'"
-     >
-      ログアウト
-     </button>
-     <!-- ハンバーガーメニューアイコン（横幅760px以下で表示） -->
-     <button class="md:hidden text-white focus:outline-none" aria-label="メニュー">
-      <!-- 画像を埋め込む -->
-      <img
-       src="{% static 'admin/img/hamburgur.png' %}"
-       alt="ハンバーガーメニュー"
-       class="hamburger-menu md:hidden"
-       style="height: 40px; width: auto; object-fit: contain; float: left"
-      />
-     </button>
-    </div>
-   </nav>
-  </div>
- </header>
-
-
- <!-- モバイルメニュー（横幅760px以下でハンバーガーメニューを押したら表示） -->
- <div
-  id="mobileMenu"
-  class="hidden fixed top-0 right-0 w-1/2 h-full z-20 bg-blackGreen bg-opacity-80 md:hidden"
- >
-  <!-- 閉じるボタン -->
-  <img
-   id="closeMenuButton"
-   src="{% static 'admin/img/close_button.png' %}"
-   alt="閉じるボタン"
-   class="absolute top-11 right-2 h-6 w-auto cursor-pointer z-30"
-  />
-
-  <!-- メニューのコンテンツが含まれるコンテナ -->
-  <div class="container mx-auto px-4 h-full flex flex-col justify-center items-center z-30">
-   <!-- メニューのリスト -->
-   <ul class="text-white text-center space-y-4">
-    <li>
-     <a href="{% url 'activity:home' %}" class="hover:underline">ホーム</a>
-    </li>
-    <li>
-     <a href="{% url 'activity:activity_list' %}" class="hover:underline">レコード</a>
-    </li>
-    <li>
-     <a href="{% url 'activity:activity_add' %}" class="hover:underline">入力画面</a>
-    </li>
-    <li>
-     <a href="{% url 'categories:category_add' %}" class="hover:underline">カテゴリー</a>
-    </li>
-    <li>
-     <button type="submit" class="bg-white text-blackGreen px-4 py-1 rounded-full mt-4"
-     onclick="window.location.href='{% url 'users:logout' %}'"
-     >
-      ログアウト
-     </button>
-    </li>
-   </ul>
-  </div>
- </div>
-
-
+  
  <!-- 左上のホーム＞のやつを作成 -->
  <div class="container mx-auto px-4 pt-20 text-textBlack">
   <nav class="text-lg">
    <a href="{% url 'activity:home' %}" class="hover:underline text-#474747">ホーム</a>
    <span> &gt; </span>
-   <span>レコード</span>
+   <span>アクティビティリスト</span>
   </nav>
  </div>
 
 
 <!-- タイトルの作成 -->
 <h1 class="container mx-auto px-4 pt-4 text-center bg-snow text-xl md:text-3xl text-textBlack">
-  レコード
+  アクティビティ一覧
  </h1>
  <hr class="mx-10 my-4 border-2 border-blackGreen shadow-md" />
 
@@ -289,16 +204,5 @@ bg-snow text-textBlack font-NotoSans
     deleteModal.style.display = 'none';  // モーダルウィンドウの非表示
   });
   </script> 
-
-
-
-  
- {% comment %} APIエンドポイントをジャバスクリプトで使用するため {% endcomment %}
- <script>
-  const apiUrl = "{% url 'activity:activity_list' %}";
-</script>
-  <script src="{% static 'admin/js/activity_list.js' %}"></script>
-  <script src="{% static 'admin/js/home.js' %}"></script>
-
 
 {% endblock content%}

--- a/django/templates/base.html
+++ b/django/templates/base.html
@@ -1,3 +1,4 @@
+{% load static %}
 <!DOCTYPE html>
 <html lang="ja">
  <head>
@@ -15,9 +16,7 @@
   {% comment %} 一部だけ子テンプレートで読み込ませたい時使う。 {% endcomment %}
   {% block extra_head %}{% endblock %}
   {% block extra_styles %}{% endblock %}
-
-  {% comment %} タイトルの継承ってどうやるんだろ {% endcomment %}
-  <title>本番環境の方やで</title>
+  {% block title %}{% endblock %}
 
   {% comment %} フォント設定。 {% endcomment %}
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -74,12 +73,107 @@
 
 
 
-
-
  </head>
 
  {% comment %} body classの継承のやり方。 {% endcomment %}
  <body class="{% block body_class %}default-class{% endblock body_class %}">
+
+  {% comment %} モーダルのjs（home.js）は共通で読み込む {% endcomment %}
+  <script src="{% static 'admin/js/home.js' %}"></script>
+
+  {% comment %} ヘッダーメニュー、モバイルメニューを継承 {% endcomment %}
+  <!-- ナビゲーションバーを作成 lgは1024pxからのサイズ-->
+<header class="bg-blackGreen w-full fixed top-0 left-0 h-10 lg:h-20 z-10">
+  <div class="container mx-auto px-4 h-full">
+   <nav class="flex items-center justify-between h-full">
+    <div class="flex items-center">
+     <a href="{% url 'activity:home' %}" class="transform hover:scale-105 transition duration-300">
+      <img
+       src="{% static 'admin/img/kotukotu_thumbnail.png' %}"
+       alt="サムネイルのカメの画像"
+       class="h-10 lg:h-20 w-auto py-1 object-cover rounded-xl"
+      />
+     </a>
+    </div>
+    <div class="flex items-center">
+     <ul class="hidden md:flex space-x-8 text-white">
+      <li>
+       <a href="{% url 'activity:home' %}" class="hover:underline">ホーム</a>
+      </li>
+      <li>
+       <a href="{% url 'activity:activity_list' %}" class="hover:underline">アクティビティ</a>
+      </li>
+      <li>
+       <a href="{% url 'activity:activity_add' %}" class="hover:underline">記録画面</a>
+      </li>
+      <li>
+       <a href="{% url 'categories:category_add' %}" class="hover:underline">カテゴリー追加</a>
+      </li>
+     </ul>
+     <button
+      type="submit"
+      class="bg-white text-blackGreen px-4 py-1 rounded-full ml-4 hidden md:block"
+      onclick="window.location.href='{% url 'users:logout' %}'"
+     >
+      ログアウト
+     </button>
+     <!-- ハンバーガーメニューアイコン（横幅760px以下で表示） -->
+     <button class="md:hidden text-white focus:outline-none" aria-label="メニュー">
+      <!-- 画像を埋め込む -->
+      <img
+       src="{% static 'admin/img/hamburgur.png' %}"
+       alt="ハンバーガーメニュー"
+       class="hamburger-menu md:hidden"
+       style="height: 40px; width: auto; object-fit: contain; float: left"
+      />
+     </button>
+    </div>
+   </nav>
+  </div>
+ </header>
+ 
+ <!-- モバイルメニュー（横幅760px以下でハンバーガーメニューを押したら表示） -->
+ <div
+  id="mobileMenu"
+  class="hidden fixed top-0 right-0 w-1/2 h-full z-20 bg-blackGreen bg-opacity-80 md:hidden"
+ >
+  <!-- 閉じるボタン -->
+  <img
+   id="closeMenuButton"
+   src="{% static 'admin/img/close_button.png' %}"
+   alt="閉じるボタン"
+   class="absolute top-11 right-2 h-6 w-auto cursor-pointer z-30"
+  />
+ 
+  <!-- メニューのコンテンツが含まれるコンテナ -->
+  <div class="container mx-auto px-4 h-full flex flex-col justify-center items-center z-30">
+   <!-- メニューのリスト -->
+   <ul class="text-white text-center space-y-4">
+    <li>
+     <a href="{% url 'activity:home' %}" class="hover:underline">ホーム</a>
+    </li>
+    <li>
+     <a href="{% url 'activity:activity_list' %}" class="hover:underline">アクティビティ</a>
+    </li>
+    <li>
+     <a href="{% url 'activity:activity_add' %}" class="hover:underline">記録画面</a>
+    </li>
+    <li>
+     <a href="{% url 'categories:category_add' %}" class="hover:underline">カテゴリー追加</a>
+    </li>
+    <li>
+     <button
+      type="submit"
+      class="bg-white text-blackGreen px-4 py-1 rounded-full mt-4"
+      onclick="window.location.href='{% url 'users:logout' %}'"
+     >
+      ログアウト
+     </button>
+    </li>
+   </ul>
+  </div>
+ </div>
+ 
   {% block content %} {% endblock content %}
  </body>
 </html>

--- a/django/templates/category_add.html
+++ b/django/templates/category_add.html
@@ -4,102 +4,15 @@
 bg-snow text-textBlack font-NotoSans 
 {% endblock body_class %}
 
+{% block title %}
+<title>カテゴリー追加</title>
+{% endblock %}
+
 {% load static %}
 
 {% block content %}
-<script src="{% static 'static/admin/js/category_add.js' %}"></script>
-
-<!-- ナビゲーションバーを作成 lgは1024pxからのサイズ-->
-<header class="bg-blackGreen w-full fixed top-0 left-0 h-10 lg:h-20 z-10">
- <div class="container mx-auto px-4 h-full">
-  <nav class="flex items-center justify-between h-full">
-   <div class="flex items-center">
-    <a href="{% url 'activity:home' %}" class="transform hover:scale-105 transition duration-300">
-     <img
-      src="{% static 'static/admin/img/kotukotu_thumbnail.png' %}"
-      alt="サムネイルのカメの画像"
-      class="h-10 lg:h-20 w-auto py-1 object-cover rounded-xl"
-     />
-    </a>
-   </div>
-   <div class="flex items-center">
-    <ul class="hidden md:flex space-x-8 text-white">
-     <li>
-      <a href="{% url 'activity:home' %}" class="hover:underline">ホーム</a>
-     </li>
-     <li>
-      <a href="{% url 'activity:activity_list' %}" class="hover:underline">レコード</a>
-     </li>
-     <li>
-      <a href="{% url 'activity:activity_add' %}" class="hover:underline">入力</a>
-     </li>
-     <li>
-      <a href="{% url 'categories:category_add' %}" class="hover:underline">カテゴリー</a>
-     </li>
-    </ul>
-    <button
-     type="submit"
-     class="bg-white text-blackGreen px-4 py-1 rounded-full ml-4 hidden md:block"
-     onclick="window.location.href='{% url 'users:logout' %}'"
-    >
-     ログアウト
-    </button>
-    <!-- ハンバーガーメニューアイコン（横幅760px以下で表示） -->
-    <button class="md:hidden text-white focus:outline-none" aria-label="メニュー">
-     <!-- 画像を埋め込む -->
-     <img
-      src="{% static 'admin/img/hamburgur.png' %}"
-      alt="ハンバーガーメニュー"
-      class="hamburger-menu md:hidden"
-      style="height: 40px; width: auto; object-fit: contain; float: left"
-     />
-    </button>
-   </div>
-  </nav>
- </div>
-</header>
-
-<!-- モバイルメニュー（横幅760px以下でハンバーガーメニューを押したら表示） -->
-<div
- id="mobileMenu"
- class="hidden fixed top-0 right-0 w-1/2 h-full z-20 bg-blackGreen bg-opacity-80 md:hidden"
->
- <!-- 閉じるボタン -->
- <img
-  id="closeMenuButton"
-  src="{% static 'admin/img/close_button.png' %}"
-  alt="閉じるボタン"
-  class="absolute top-11 right-2 h-6 w-auto cursor-pointer z-30"
- />
-
- <!-- メニューのコンテンツが含まれるコンテナ -->
- <div class="container mx-auto px-4 h-full flex flex-col justify-center items-center z-30">
-  <!-- メニューのリスト -->
-  <ul class="text-white text-center space-y-4">
-   <li>
-    <a href="{% url 'activity:home' %}" class="hover:underline">ホーム</a>
-   </li>
-   <li>
-    <a href="{% url 'activity:activity_list' %}" class="hover:underline">レコード</a>
-   </li>
-   <li>
-    <a href="{% url 'activity:activity_add' %}" class="hover:underline">入力画面</a>
-   </li>
-   <li>
-    <a href="{% url 'categories:category_add' %}" class="hover:underline">カテゴリー</a>
-   </li>
-   <li>
-    <button
-     type="submit"
-     class="bg-white text-blackGreen px-4 py-1 rounded-full mt-4"
-     onclick="window.location.href='{% url 'users:logout' %}'"
-    >
-     ログアウト
-    </button>
-   </li>
-  </ul>
- </div>
-</div>
+{% comment %} クリップボード保存機能を持たせている。 {% endcomment %}
+<script src="{% static 'admin/js/category_add.js' %}"></script>
 
 <!-- 左上のホーム＞のやつを作成 -->
 <div class="container mx-auto px-4 pt-20 text-textBlack">
@@ -158,8 +71,7 @@ bg-snow text-textBlack font-NotoSans
   </form>
 </div>
 
-{% comment %} クリップボード保存機能を持たせている。 {% endcomment %}
-<script src="{% static 'static/admin/js/category_add.js' %}"></script>
+
 
 
 

--- a/django/templates/home.html
+++ b/django/templates/home.html
@@ -10,58 +10,15 @@
 bg-snow text-textBlack font-NotoSans
 {% endblock body_class %}
 
+{% block title %}
+<title>ホーム</title>
+{% endblock %}
+
 {% load static %}
 {% block content %}
 
-<!-- ナビゲーションバーを作成 lgは1024pxからのサイズ-->
-<header class="bg-blackGreen w-full fixed top-0 left-0 h-10 lg:h-20 z-10">
-  <div class="container mx-auto px-4 h-full">
-   <nav class="flex items-center justify-between h-full">
-    <div class="flex items-center">
-     <a href="#" class="transform hover:scale-105 transition duration-300">
-      <img
-       src="{% static 'admin/img/kotukotu_thumbnail.png' %}"
-       alt="サムネイルのカメの画像"
-       class="h-10 lg:h-20 w-auto py-1 object-cover rounded-xl"
-      />
-     </a>
-    </div>
-    <div class="flex items-center">
-     <ul class="hidden md:flex space-x-8 text-white">
-      <li>
-       <a href="#" class="hover:underline">ホーム</a>
-      </li>
-      <li>
-       <a href="{% url 'activity:activity_list' %}" class="hover:underline">レコード</a>
-      </li>
-      <li>
-       <a href="{% url 'activity:activity_add' %}" class="hover:underline">記録</a>
-      </li>
-      <li>
-       <a href="{% url 'categories:category_add' %}" class="hover:underline">カテゴリー</a>
-      </li>
-     </ul>
-     <button
-      type="submit"
-      class="bg-white text-blackGreen px-4 py-1 rounded-full ml-4 hidden md:block"
-      onclick="window.location.href='{% url 'users:logout' %}'"
-     >
-      ログアウト
-     </button>
-     <!-- ハンバーガーメニューアイコン（横幅760px以下で表示） -->
-     <button class="md:hidden text-white focus:outline-none" aria-label="メニュー">
-      <!-- 画像を埋め込む -->
-      <img
-       src="{% static 'admin/img/hamburgur.png' %}"
-       alt="ハンバーガーメニュー"
-       class="hamburger-menu md:hidden"
-       style="height: 40px; width: auto; object-fit: contain; float: left"
-      />
-     </button>
-    </div>
-   </nav>
-  </div>
- </header>
+<script src="{% static 'admin/js/categories_list.js' %}"></script>
+<script type="module" src="{% static 'admin/js/graph.js' %}"></script>
 
  <!-- 左上のホーム＞のやつを作成 -->
  <div class="container mx-auto px-4 pt-20 text-textBlack">
@@ -142,54 +99,6 @@ bg-snow text-textBlack font-NotoSans
 </div>
 
 
-
-
- <!-- モバイルメニュー（横幅760px以下でハンバーガーメニューを押したら表示） -->
- <div
-  id="mobileMenu"
-  class="hidden fixed top-0 right-0 w-1/2 h-full z-20 bg-blackGreen bg-opacity-80 md:hidden"
- >
-  <!-- 閉じるボタン -->
-  <img
-   id="closeMenuButton"
-   src="{% static 'admin/img/close_button.png' %}"
-   alt="閉じるボタン"
-   class="absolute top-11 right-2 h-6 w-auto cursor-pointer z-30"
-  />
-
-  <!-- メニューのコンテンツが含まれるコンテナ -->
-  <div class="container mx-auto px-4 h-full flex flex-col justify-center items-center z-30">
-   <!-- メニューのリスト -->
-   <ul class="text-white text-center space-y-4">
-    <li>
-     <a href="#" class="hover:underline">ホーム</a>
-    </li>
-    <li>
-     <a href="{% url 'activity:activity_list' %}" class="hover:underline">レコード</a>
-    </li>
-    <li>
-     <a href="{% url 'activity:activity_add' %}" class="hover:underline">記録</a>
-    </li>
-    <li>
-     <a href="{% url 'categories:category_add' %}" class="hover:underline">カテゴリー</a>
-    </li>
-    <li>
-     <button type="submit" class="bg-white text-blackGreen px-4 py-1 rounded-full mt-4"
-     onclick="window.location.href='{% url 'users:logout' %}'"
-     >
-      ログアウト
-     </button>
-    </li>
-   </ul>
-  </div>
- </div>
-
- <script src="{% static 'admin/js/home.js' %}"></script>
- <script src="{% static 'admin/js/categories_list.js' %}"></script>
- <script type="module" src="{% static 'admin/js/graph.js' %}"></script>
- 
-
-
 {% comment %} 以降は元々作ってくれたもの。 {% endcomment %}
   {% comment %} <h1>ホーム画面です</h1>
   <a href="{% url 'users:logout' %}">ログアウト</a>
@@ -199,7 +108,7 @@ bg-snow text-textBlack font-NotoSans
 
   <h1>日々の積み上げ記録</h1>
   <p>
-    {{ username }}さん今日も頑張りましょう
+    {{ user_name }}さん今日も頑張りましょう
   </p>
   <p>
     累計時間:{{ total_duration }}

--- a/nginx/static/admin/js/category_add.js
+++ b/nginx/static/admin/js/category_add.js
@@ -1,0 +1,20 @@
+const copyToClipboard = async text => {
+ try {
+  // 'navigator.clipboard'が存在し、利用可能であることを確認します。
+  if (!navigator.clipboard) {
+   // この場合、クリップボードへの書き込みは不可能なので、エラーメッセージを出力します。
+   throw new Error("Clipboard API not available");
+  }
+
+  // 'navigator.clipboard.writeText' 関数は、与えられたテキストをクリップボードに書き込むための非同期関数です。
+  // 'await' キーワードを使用して、この非同期操作が完了するのを待ちます。
+  await navigator.clipboard.writeText(text);
+
+  // クリップボードへのコピーが成功したら、アラートを表示してユーザーに通知します。
+  alert("Copied color code: " + text);
+ } catch (err) {
+  // もし何らかの理由でクリップボードへのコピーが失敗した場合（例えば、ブラウザが対応していない場合など）は、
+  // エラーメッセージをコンソールに出力します。これは開発者が問題をデバッグするのに役立ちます。
+  console.error("Failed to copy text: ", err);
+ }
+};


### PR DESCRIPTION
## 目的
-冗長的になっていたhtmlを整理することで、他の人がアサインしやすくなる

## 実装の概要/やったこと

- 各htmlはbase.htmlから重複部分をbase.htmlから継承するようになった。また静的ファイルのバグを修正した

## 保留/やらないこと

home.htmlでカテゴリーリストが表示されなくなった。JSONの調整で実施予定

## できるようになること（ユーザ目線）

なし

## できなくなること（ユーザ目線）

-なし

## 動作確認

- 本番環境で行った。nginxの挙動が変わると動かなくなる恐れがるが、その際は読み取り先のnginxのjsを調整する

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #17 #13 
- @hiroki-rr 
