### PR TITLE
ホーム画面をバックエンドと連携

### DIFF
--- a/django/categories/models.py
+++ b/django/categories/models.py
@@ -12,7 +12,7 @@ class Category(models.Model):
     is_deleted = models.BooleanField(default=False)
 
     def __str__(self):
-        return f"{self.name}[{self.goal}]"
+        return f"{self.name}"
 
 class ActivityCategory(models.Model):
     category = models.ForeignKey(Category, on_delete=models.PROTECT)

--- a/django/static/admin/js/categories_list.js
+++ b/django/static/admin/js/categories_list.js
@@ -1,65 +1,67 @@
-// テスト用のカテゴリデータの配列を定義
-const categories = [
- {
-  categoryColor: "#DABEB7",
-  categoryName: "プログラミング",
-  categoryDuration: "00:30"
- },
- {
-  categoryColor: "#B7C1DA",
-  categoryName: "タイピング",
-  categoryDuration: "01:15"
- },
- {
-  categoryColor: "#DAD4B7",
-  categoryName: "英語",
-  categoryDuration: "00:45"
- }
-];
+(async () => {
+  try {
+    const response = await fetch('/categories/categories_json/');
+    const categories = await response.json();
 
-// HTMLのid属性が"category-list"の要素を取得
-const categoryList = document.getElementById("category-list");
-// 768px以下の画面幅用のcategory-list要素を取得
-const categoryListMobile = document.getElementById("category-list-mobile");
+    // HTMLのid属性が"category-list"の要素を取得
+    const categoryList = document.getElementById("category-list");
+    // 768px以下の画面幅用のcategory-list要素を取得
+    const categoryListMobile = document.getElementById("category-list-mobile");
 
-// categories配列内の各要素に対して処理を実行
-categories.forEach(category => {
- // 新しいdiv要素を作成
- const categoryElement = document.createElement("div");
- // 作成したdiv要素にCSSクラスを設定
- categoryElement.className = `bg-${category.categoryColor} text-textBlack rounded-lg p-4 w-64 h-12 flex justify-between items-center mb-4`;
- // 作成したdiv要素の背景色を設定
- categoryElement.style.backgroundColor = category.categoryColor;
+    // データが存在しない場合
+    //* カテゴリーが存在しません。とpタグでエラー文をを表示しています。
+    //! 変更する必要があれば調整お願いします。
+    if (categories.length === 0) {
+      const noDataMessage = document.createElement("p");
+      noDataMessage.textContent = "カテゴリーが存在しません。";
+      categoryList.appendChild(noDataMessage);
+      if (categoryListMobile) {
+        const noDataMessageMobile = noDataMessage.cloneNode(true);
+        categoryListMobile.appendChild(noDataMessageMobile);
+      }
+    } else {
+      // データが存在する場合
+      categories.forEach(category => {
+        // 新しいdiv要素を作成
+        const categoryElement = document.createElement("div");
+        // 作成したdiv要素にCSSクラスを設定
+        categoryElement.className = `bg-${category.color_code} text-textBlack rounded-lg p-4 w-64 h-12 flex justify-between items-center mb-4`;
+        // 作成したdiv要素の背景色を設定
+        categoryElement.style.backgroundColor = category.color_code;
 
- // 新しいspan要素を作成
- const categoryName = document.createElement("span");
- // 作成したspan要素にCSSクラスを設定
- categoryName.className = "category-name";
- // 作成したspan要素にテキストコンテンツを設定
- categoryName.textContent = category.categoryName;
- // div要素にspan要素を追加（カテゴリ名を表示）
- categoryElement.appendChild(categoryName);
+        // 新しいspan要素を作成
+        const categoryName = document.createElement("span");
+        // 作成したspan要素にCSSクラスを設定
+        categoryName.className = "category-name";
+        // 作成したspan要素にテキストコンテンツを設定
+        categoryName.textContent = category.name;
+        // div要素にspan要素を追加（カテゴリ名を表示）
+        categoryElement.appendChild(categoryName);
 
- // 新しいspan要素を作成
- const categoryDuration = document.createElement("span");
- // 作成したspan要素にCSSクラスを設定
- categoryDuration.className = "category-duration";
- // 作成したspan要素にテキストコンテンツを設定（累計時間を表示）
- categoryDuration.textContent = `累計時間 ${category.categoryDuration}`;
- // div要素にspan要素を追加（累計時間を表示）
- categoryElement.appendChild(categoryDuration);
+        // 新しいspan要素を作成
+        const categoryDuration = document.createElement("span");
+        // 作成したspan要素にCSSクラスを設定
+        categoryDuration.className = "category-duration";
+        // 作成したspan要素にテキストコンテンツを設定（累計時間を表示）
+        categoryDuration.textContent = `累計時間 ${category.total_duration}`;
+        // div要素にspan要素を追加（累計時間を表示）
+        categoryElement.appendChild(categoryDuration);
 
- // categoryList要素に作成したdiv要素を追加
- if (categoryList) {
-  categoryList.appendChild(categoryElement);
- }
-
- // 768px以下の画面幅用に要素を複製
- if (categoryListMobile) {
-  const categoryElementMobile = categoryElement.cloneNode(true);
-  // 作成したdiv要素にCSSクラスを設定
-  categoryElementMobile.className = `bg-${category.categoryColor} text-textBlack rounded-lg p-2 mx-auto w-full h-12 flex justify-between items-center mb-4 mx-8`;
-  // categoryListMobile要素に作成したdiv要素
-  categoryListMobile.appendChild(categoryElementMobile);
- }
-});
+        // categoryList要素に作成したdiv要素を追加
+        if (categoryList) {
+          categoryList.appendChild(categoryElement);
+        }
+        // 768px以下の画面幅用に要素を複製
+        if (categoryListMobile) {
+          const categoryElementMobile = categoryElement.cloneNode(true);
+          // 作成したdiv要素にCSSクラスを設定
+          categoryElementMobile.className = `bg-${category.color_code} text-textBlack rounded-lg p-2 mx-auto w-full h-12 flex justify-between items-center mb-4 mx-8`;
+          // categoryListMobile要素に作成したdiv要素
+          categoryListMobile.appendChild(categoryElementMobile);
+        }
+      });
+    }
+  } catch (error) {
+    console.error("エラーが発生しました:", error);
+  }
+})();

--- a/django/static/admin/js/categories_list.js
+++ b/django/static/admin/js/categories_list.js
@@ -51,6 +51,7 @@
         if (categoryList) {
           categoryList.appendChild(categoryElement);
         }
+
         // 768px以下の画面幅用に要素を複製
         if (categoryListMobile) {
           const categoryElementMobile = categoryElement.cloneNode(true);
@@ -58,6 +59,19 @@
           categoryElementMobile.className = `bg-${category.color_code} text-textBlack rounded-lg p-2 mx-auto w-full h-12 flex justify-between items-center mb-4 mx-8`;
           // categoryListMobile要素に作成したdiv要素
           categoryListMobile.appendChild(categoryElementMobile);
+        }
+
+        // div要素をクリックしたときのイベントリスナーを追加
+        categoryElement.addEventListener("click", () => {
+          // クリックしたときに詳細ページに遷移する
+          window.location.href = `/categories/${category.id}/`;
+        });
+
+        if (categoryListMobile) {
+          const categoryElementMobile = categoryListMobile.lastChild;
+          categoryElementMobile.addEventListener("click", () => {
+            window.location.href = `/categories/${category.id}/`;
+          });
         }
       });
     }

--- a/django/static/admin/js/graph.js
+++ b/django/static/admin/js/graph.js
@@ -10,7 +10,7 @@ let barChart;  // barChartをグローバルスコープで宣言
     const data = await response.json();
 
     // データをコンソールにログとして出力します（デバッグ用）
-    console.log(data);
+    // console.log(data);
 
     // HTMLの指定の要素に累計日数と累計時間を表示します
     document.getElementById('totalDays').textContent = data.total_days;

--- a/django/static/admin/js/graph.js
+++ b/django/static/admin/js/graph.js
@@ -1,65 +1,69 @@
-// データ
-const receivedData = {
- date_list: ["5/7", "5/8", "5/9", "5/10", "5/11", "5/12", "5/13"],
- category_duration_lists: {
-  1: ["1.0", "2.0", "1.5", "0.0", "2.0", "1.5", "2.0"],
-  2: ["0.0", "0.5", "1.0", "1.5", "1.0", "1.0", "0.5"],
-  3: ["1.0", "1.0", "1.0", "1.0", "1.0", "1.0", "1.0"]
- },
- uncategorized_duration_list: ["2.0", "1.5", "1.0", "2.0", "1.0", "1.5", "2.0"],
- total_days: 7,
- total_duration: "30:0",
- category_colors: {
-  1: "#DABEB7",
-  2: "#B7C1DA",
-  3: "#DAD4B7"
- }
-};
+// 非同期関数を定義します
+let barChart;  // barChartをグローバルスコープで宣言
 
-// データセットを作成
-const datasets = Object.keys(receivedData.category_duration_lists).map(categoryId => ({
- label: `Category ${categoryId}`,
- data: receivedData.category_duration_lists[categoryId].map(Number),
- backgroundColor: receivedData.category_colors[categoryId],
- borderColor: receivedData.category_colors[categoryId],
- borderWidth: 1
-}));
+(async () => {
+  try {
+    // '/activity/ajax_get_data/'というURLからデータを非同期で取得します
+    const response = await fetch('/activity/ajax_get_data/');
 
-// 未分類のデータセットを追加
-datasets.push({
- label: "Uncategorized",
- data: receivedData.uncategorized_duration_list.map(Number),
- backgroundColor: "#8AA7A1",
- borderColor: "#8AA7A1",
- borderWidth: 1
-});
+    // 取得したデータをJSON形式でパースします
+    const data = await response.json();
 
-// バーチャートデータを作成
-const barChartData = {
- labels: receivedData.date_list,
- datasets: datasets
-};
+    // データをコンソールにログとして出力します（デバッグ用）
+    console.log(data);
 
-const config = {
- type: "bar",
- data: barChartData,
- options: {
-  responsive: true,
-  maintainAspectRatio: false,
-  scales: {
-   y: {
-    beginAtZero: true,
-    stacked: true,
-    ticks: {
-     stepSize: 2,
-     max: 8
+    // HTMLの指定の要素に累計日数と累計時間を表示します
+    document.getElementById('totalDays').textContent = data.total_days;
+    document.getElementById('totalDuration').textContent = data.total_duration;
+
+    // 各カテゴリーごとにデータセットを作成します
+    // 'map'関数を使って各カテゴリーのデータセットを作り、それを'datasets'配列に追加します
+    const datasets = Object.keys(data.category_duration_lists).map(category => ({
+      label: category,  // カテゴリー名をラベルとして設定します
+      data: data.category_duration_lists[category].map(Number),  // 各カテゴリーのデータを数値として設定します
+      backgroundColor: data.category_colors[category],  // 各カテゴリーの色を背景色として設定します
+      borderColor: data.category_colors[category],  // 各カテゴリーの色をボーダー色として設定します
+      borderWidth: 1  // ボーダーの幅を1とします
+    }));
+
+    // バーチャートのデータを作成します
+    const barChartData = {
+      labels: data.date_list,  // データの日付をラベルとして設定します
+      datasets: datasets  // 先ほど作成したデータセットを設定します
+    };
+
+    // チャートの設定を作成します
+    const config = {
+      type: "bar",  // チャートのタイプを'bar'（バーチャート）とします
+      data: barChartData,  // 先ほど作成したバーチャートのデータを設定します
+      options: {
+        responsive: true,  // レスポンシブ対応をオンにします
+        scales: {
+          x: {
+            stacked: true,  // X軸（水平軸）を積み上げバーにします
+          },
+          y: {
+            beginAtZero: true,  // Y軸（垂直軸）の始点を0にします
+            stacked: true,  // Y軸を積み上げバーにします
+            tickes: {
+              stepSize: 2,
+              max: 8
+            }
+          }
+        }
+      }
+    };
+
+    // 既存のチャートが存在すれば破棄します
+    if (barChart) {
+      barChart.destroy();
     }
-   },
-   x: {
-    stacked: true // 縦に積み上げ
-   }
-  }
- }
-};
 
-const barChart = new Chart(document.getElementById("barChart"), config);
+    // チャートを作成します
+    barChart = new Chart(document.getElementById('barChart'), config);
+
+  } catch (error) {
+    // エラーが発生した場合はそれをコンソールにログとして出力します
+    console.error('Error:', error);
+  }
+})();  // 定義した非同期関数を実行します

--- a/django/templates/home.html
+++ b/django/templates/home.html
@@ -95,40 +95,7 @@ bg-snow text-textBlack font-NotoSans
 </div>
 </div>
 
-
-{% comment %} 以降は元々作ってくれたもの。 {% endcomment %}
-  {% comment %} <h1>ホーム画面です</h1>
-  <a href="{% url 'users:logout' %}">ログアウト</a>
-
-  <a href="{% url 'activity:activity_list' %}">レコード画面へ</a>
-  <a href="{% url 'activity:activity_add' %}">積み上げを記録する</a> {% endcomment %}
-
-  {% comment %} <h1>日々の積み上げ記録</h1>
-  <p>
-    {{ user_name }}さん今日も頑張りましょう
-  </p>
-  <p>
-    累計時間:{{ total_duration }}
-  </p>
-  <p>
-    累計日数:{{ total_days }}日
-  </p>
-  <p>日付</p>
-  <ul>
-    {% for date in date_list %}
-      <li>{{ date }}</li>
-    {% endfor %}
-  </ul>
-  <p>時間</p>
-  <ul>
-    {% for duration in duration_list %}
-      <li>{{ duration }}</li>
-    {% endfor %}
-  </ul>
-
-  <a href="{% url 'categories:category_add' %}">カテゴリーを作成する</a> {% endcomment %}
-
-  <script src="{% static 'admin/js/categories_list.js' %}"></script>
+<script src="{% static 'admin/js/categories_list.js' %}"></script>
 <script src="{% static 'admin/js/graph.js' %}"></script>
 <script type="module" src="{% static 'admin/js/graph.js' %}"></script>
 

--- a/django/templates/home.html
+++ b/django/templates/home.html
@@ -97,7 +97,6 @@ bg-snow text-textBlack font-NotoSans
 
 <script src="{% static 'admin/js/categories_list.js' %}"></script>
 <script src="{% static 'admin/js/graph.js' %}"></script>
-<script type="module" src="{% static 'admin/js/graph.js' %}"></script>
 
 
 {% endblock content %}


### PR DESCRIPTION
## 目的
- ホーム画面の表記をバックエンドと連携

## 実装の概要/やったこと
- categories_list.jsの編集
    - カテゴリーの色・時間・名前が反映できるように。
    - 押下でカテゴリーの詳細ページへ遷移
- graph.jsの編集
    - グラフを縦積みでカテゴリーごとに表記
    - カテゴリーの色・名前・時間が反映されるように
- その他/home.htmlの調整, models.pyの調整

## 保留/やらないこと
- なし

## できるようになること（ユーザ目線）
- 積み上げの可視化

## できなくなること（ユーザ目線）
- なし

## 動作確認
- ブラウザ上でDBのデータが適切に表示されているかの確認

## その他
- categories.jsについてですが、カテゴリーがなかった場合の処理を書いていなかったので一旦pタグで「カテゴリーが存在しません」と表示するようにしています。そこの調整があればお願いします。
- close #12 
- @hosomatu 
