### PR TITLE
activity_add.htmlのバックエンドとの連携

### DIFF
--- a/django/activity/views.py
+++ b/django/activity/views.py
@@ -123,12 +123,12 @@ class ActivityAddView(LoginRequiredMixin, generic.CreateView):
         kwargs.update({'user': self.request.user})
         return kwargs
     
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        # カテゴリーリストを取得し、contextに追加する
-        categories = Category.objects.filter(user=self.request.user, is_deleted=False)
-        context['categories'] = categories
-        return context
+    # def get_context_data(self, **kwargs):
+    #     context = super().get_context_data(**kwargs)
+    #     # カテゴリーリストを取得し、contextに追加する
+    #     categories = Category.objects.filter(user=self.request.user, is_deleted=False)
+    #     context['categories'] = categories
+    #     return context
 
 
     # POSTリクエストの場合、ajax_submitメソッドを呼び出す

--- a/django/activity/views.py
+++ b/django/activity/views.py
@@ -122,6 +122,13 @@ class ActivityAddView(LoginRequiredMixin, generic.CreateView):
         kwargs = super(ActivityAddView, self).get_form_kwargs()
         kwargs.update({'user': self.request.user})
         return kwargs
+    
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        # カテゴリーリストを取得し、contextに追加する
+        categories = Category.objects.filter(user=self.request.user, is_deleted=False)
+        context['categories'] = categories
+        return context
 
 
     # POSTリクエストの場合、ajax_submitメソッドを呼び出す

--- a/django/static/admin/js/activity_add.js
+++ b/django/static/admin/js/activity_add.js
@@ -15,46 +15,79 @@ document.getElementById("close-modal").addEventListener("click", function () {
 
 // フォームの送信後、エラーもしくは、データを取得してからモーダル出力する流れ。（バックエンドで記載していたもの）
 
-// フォームを送信する非同期関数
 async function submitForm() {
- // フォームデータを取得
- const formData = new FormData(document.querySelector(".activityRecordForm"));
- // フォームデータを送信
- const response = await fetch('{% url "activity:activity_add" %}', {
-  method: "POST",
-  body: formData,
-  headers: {
-   "X-CSRFToken": document.querySelector("[name=csrfmiddlewaretoken]").value
+  // フォームデータを取得
+  const formData = new FormData(document.querySelector("#activityRecordForm"));
+
+    // 必須フィールドのチェック
+  if (!formData.get('date') || !formData.get('duration')) {
+    alert("時間と日付の入力は必須です");
+    return;
   }
- });
 
- // Jsonデータを取得
- const data = await response.json();
+  // 時間要素から入力された時間を取得し、分単位に変換
+  const timeInput = document.querySelector('input[type="time"]');
+  const [hours, minutes] = timeInput.value.split(':').map(Number);
+  const durationInMinutes = hours * 60 + minutes;
 
- // 送信が成功した場合『ここからモーダルの要素、合わせる部分』
- if (data.success) {
+  // 分単位のデータをフォームデータに追加
+  formData.set('duration', durationInMinutes);
+
+  // フォームデータを送信
+  const csrf_token = document.querySelector("[name=csrfmiddlewaretoken]").value;
+  const response = await fetch('/activity/add/', {
+    method: "POST",
+    body: formData,
+    headers: {
+    "X-CSRFToken": csrf_token
+    }
+  });
+
+  // Jsonデータを取得
+  const data = await response.json();
+
+  // 送信が成功した場合『ここからモーダルの要素、合わせる部分』
+  if (data.success) {
   // 累計日数を取得
-  const totalDaysResponse = await fetch('{% url "activity:get_total_days" %}');
+  const totalDaysResponse = await fetch('/activity/get_total_days/');
   const totalDaysData = await totalDaysResponse.json();
 
   // 累計日数取得に成功した場合
   if (totalDaysResponse.ok) {
-   // 累計日数を表示
-   document.getElementById("totalDays").textContent = "活動累計日数: " + totalDaysData.total_days;
+  // 累計日数を表示
+  document.getElementById("totalDays").textContent = totalDaysData.total_days;
 
-   // モーダルを表示
-   showModal();
-   //    // 成功モーダルウィンドウの表示
-   //    document.getElementById("successModal").style.display = "block";
-   // フロントの書いた表示方法とする（ほそまつ）
+  // モーダルを表示
+  showModal();
+  // 成功モーダルウィンドウの表示
+  document.getElementById("modal-bg").style.display = "block";
   } else {
-   // エラーメッセージを表示またはログに記録
-   console.error(data.error);
+  // エラーメッセージを表示またはログに記録
+  console.error(data.error);
   }
- } else {
+  } else {
   // フォーム送信のエラーメッセージを表示
   displayErrors(data.errors);
+  }
+}
+
+// エラーメッセージを表示する関数
+function displayErrors(errors) {
+ // エラーメッセージリストの要素を取得
+ const errorMessageList = document.getElementById("errorMessageList");
+ errorMessageList.innerHTML = "";
+
+ // エラーメッセージをリストに追加
+ for (const key in errors) {
+  if (Object.prototype.hasOwnProperty.call(errors, key)) {
+   const li = document.createElement("li");
+   li.textContent = errors[key];
+   errorMessageList.appendChild(li);
+  }
  }
+
+ // エラーメッセージを表示
+ document.getElementById("errorMessages").style.display = "block";
 }
 
 // エラーメッセージを表示する関数
@@ -79,13 +112,13 @@ function displayErrors(errors) {
 // ホームボタンのイベントリスナー
 document.getElementById("homeButton").addEventListener("click", function () {
  // ホーム画面への遷移
- location.href = '{% url "activity:home" %}';
+ location.href = '/activity/';
 });
 
 // レコードボタンのイベントリスナー
 document.getElementById("recordButton").addEventListener("click", function () {
  // レコード画面への遷移
- location.href = '{% url "activity:activity_list" %}';
+ location.href = '/activity/list/';
 });
 
 // 挙動まとめ

--- a/django/templates/activity_add.html
+++ b/django/templates/activity_add.html
@@ -43,8 +43,9 @@ bg-snow text-textBlack font-NotoSans
       <img src="{% static 'admin/img/pencil-icon.png' %}" alt="category icon" class="absolute left-4 top-1/2 transform -translate-y-1/2 h-6 w-6" />
       <select id="category" name="{{ form.category.name }}" class="form-select block bg-gray-300 w-1/2 translate-x-1/2 translate-y-1/3 pl-16 pr-8 py-2 bg-transparent text-textBlack rounded-lg">
           <!-- カテゴリーオプションはJavaScriptで動的に追加する。 -->
-        {% for category in categories %}
-          <option value="{{ category.id }}">{{ category.name }}</option>
+          <option value="" selected>カテゴリー</option>
+          {% for category in form.fields.category.queryset %}
+          <option value="{{ category.id }}" {% if category.id == form.fields.category.initial %}selected{% endif %}>{{ category.name }}</option>
         {% endfor %}
       </select>
   </div>

--- a/django/templates/activity_add.html
+++ b/django/templates/activity_add.html
@@ -1,8 +1,5 @@
 {% extends 'base.html' %}
 
-{% block extra_head %}
-<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-{% endblock extra_head %}
 {% block body_class %}
 bg-snow text-textBlack font-NotoSans
 {% endblock body_class %}
@@ -42,8 +39,9 @@ bg-snow text-textBlack font-NotoSans
       <div class="absolute inset-0 bg-blackGreen rounded-lg"></div>
       <img src="{% static 'admin/img/pencil-icon.png' %}" alt="category icon" class="absolute left-4 top-1/2 transform -translate-y-1/2 h-6 w-6" />
       <select id="category" name="{{ form.category.name }}" class="form-select block bg-gray-300 w-1/2 translate-x-1/2 translate-y-1/3 pl-16 pr-8 py-2 bg-transparent text-textBlack rounded-lg">
-          <!-- カテゴリーオプションはJavaScriptで動的に追加する。 -->
-          <option value="" selected>カテゴリー</option>
+        <!-- カテゴリーオプションの初期値指定 -->
+        <option value="">カテゴリーを選択してください</option>
+        <!-- カテゴリーオプションはformsからデータを取得 -->
           {% for category in form.fields.category.queryset %}
           <option value="{{ category.id }}" {% if category.id == form.fields.category.initial %}selected{% endif %}>{{ category.name }}</option>
         {% endfor %}
@@ -61,7 +59,7 @@ bg-snow text-textBlack font-NotoSans
   <div class="relative mx-auto w-1/2 h-14">
       <div class="absolute inset-0 bg-blackGreen rounded-lg"></div>
       <img src="{% static 'admin/img/clock-icon.png' %}" alt="clock icon" class="absolute left-4 top-1/2 transform -translate-y-1/2 h-6 w-6" />
-      <input type="time" id="time" name="{{ form.time.name }}" class="block bg-gray-300 w-1/2 translate-x-1/2 translate-y-1/4 pl-16 pr-8 py-2 bg-transparent text-textBlack rounded-lg" value="00:00" />
+      <input type="time" id="duration" name="{{ form.duration.name }}" class="block bg-gray-300 w-1/2 translate-x-1/2 translate-y-1/4 pl-16 pr-8 py-2 bg-transparent text-textBlack rounded-lg" value="00:00" />
   </div>
 
   <!-- メモの入力フォーム。小さくなったときのリサイズはまた後日。 -->
@@ -132,89 +130,6 @@ bg-snow text-textBlack font-NotoSans
     </ul>
   </div>
 
-
-{% comment %}バックエンドが書いた文
-<script>
-// フォームを送信する非同期関数
-async function submitForm() {
-  // フォームデータを取得
-  const formData = new FormData(document.querySelector('.activityRecordForm'));
-
-  // 時間要素から入力された時間を取得し、分単位に変換
-  const timeInput = document.querySelector('input[type="time"]');
-  const [hours, minutes] = timeInput.value.split(':').map(Number);
-  const durationInMinutes = hours * 60 + minutes;
-
-  // 分単位のデータをフォームデータに追加
-  formData.set('duration', durationInMinutes);
-
-  // フォームデータを送信
-  const response = await fetch('{% url "activity:activity_add" %}', {
-    method: 'POST',
-    body: formData,
-    headers: {
-      'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value,
-    },
-  });
-
-    // Jsonデータを取得
-    const data = await response.json();
-
-    // 送信が成功した場合
-    if (data.success) {
-      // 累計日数を取得
-      const totalDaysResponse = await fetch('{% url "activity:get_total_days" %}');
-      const totalDaysData = await totalDaysResponse.json();
-
-      // 累計日数取得に成功した場合
-      if (totalDaysResponse.ok) {
-        // 累計日数を表示
-        document.getElementById('totalDays').textContent = '活動累計日数: ' + totalDaysData.total_days;
-
-        // 成功モーダルウィンドウの表示
-        document.getElementById('successModal').style.display = 'block';
-      } else {
-        // エラーメッセージを表示またはログに記録
-        console.error(data.error);
-      }
-    } else {
-      // フォーム送信のエラーメッセージを表示
-      displayErrors(data.errors);
-    }
-  }
-
-  // エラーメッセージを表示する関数
-  function displayErrors(errors) {
-    // エラーメッセージリストの要素を取得
-    const errorMessageList = document.getElementById('errorMessageList');
-    errorMessageList.innerHTML = '';
-
-    // エラーメッセージをリストに追加
-    for (const key in errors) {
-      if (Object.prototype.hasOwnProperty.call(errors, key)) {
-        const li = document.createElement('li');
-        li.textContent = errors[key];
-        errorMessageList.appendChild(li);
-      }
-    }
-
-    // エラーメッセージを表示
-    document.getElementById('errorMessages').style.display = 'block';
-  }
-
-  // ホームボタンのイベントリスナー
-  document.getElementById('homeButton').addEventListener('click', function() {
-    // ホーム画面への遷移
-    location.href = '{% url "activity:home" %}';
-  });
-
-  // レコードボタンのイベントリスナー
-  document.getElementById('recordButton').addEventListener('click', function() {
-    // レコード画面への遷移
-    location.href = '{% url "activity:activity_list" %}';
-  });
-</script>
-{% endcomment %}
 
 <script src="{% static 'admin/js/activity_add.js' %}"></script>
 

--- a/django/templates/activity_add.html
+++ b/django/templates/activity_add.html
@@ -1,5 +1,8 @@
 {% extends 'base.html' %}
 
+{% block extra_head %}
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+{% endblock extra_head %}
 {% block body_class %}
 bg-snow text-textBlack font-NotoSans
 {% endblock body_class %}
@@ -40,6 +43,9 @@ bg-snow text-textBlack font-NotoSans
       <img src="{% static 'admin/img/pencil-icon.png' %}" alt="category icon" class="absolute left-4 top-1/2 transform -translate-y-1/2 h-6 w-6" />
       <select id="category" name="{{ form.category.name }}" class="form-select block bg-gray-300 w-1/2 translate-x-1/2 translate-y-1/3 pl-16 pr-8 py-2 bg-transparent text-textBlack rounded-lg">
           <!-- カテゴリーオプションはJavaScriptで動的に追加する。 -->
+        {% for category in categories %}
+          <option value="{{ category.id }}">{{ category.name }}</option>
+        {% endfor %}
       </select>
   </div>
 


### PR DESCRIPTION
## 目的
activity_add.htmlのバックエンドとの連携

## 実装の概要/やったこと
カテゴリー選択の部分にforms.pyで定義されているカテゴリー一覧を取得できるように変更
時間選択フォームのidとnameの"time"の部分を"duration"に変更
エラーメッセージが左下に表示されるのでjsに必須フィールドのチェックを追加
エラーメッセージを「時間と日付の入力は必須です」に変更


## 保留/やらないこと
なし

## できるようになること（ユーザ目線）
activity_add.htmlにstyleが追加された状態で機能を使うことができる

## できなくなること（ユーザ目線）
なし

## 動作確認
ボタンをクリックしてデータの登録やエラーメッセージの表示が行われるかを確認

## その他

- htmlに記載している不要そうなコメントは削除しました
- close #33 
- @hosomatu 
