### PR TITLE
カテゴリー毎の累計日数のデータをJSONで渡す

### DIFF
--- a/django/categories/views.py
+++ b/django/categories/views.py
@@ -80,7 +80,11 @@ class CategoryDetailAjaxView(generic.DetailView):
 
         # カテゴリーの累計時間を計算
         total_duration_datetime = datetime(1, 1, 1) + timedelta(minutes=total_duration)
-        category_data['category_total_duration'] = total_duration_datetime.strftime('%H:%M')
+        category_data['category_total_duration'] = total_duration_datetime.strftime('%-H:%M')
+
+        # カテゴリーの累計日数を計算
+        category_dates = activities.values_list('date', flat=True).distinct()
+        category_data['category_total_days'] = category_dates.count()
 
         return JsonResponse(category_data)
 

--- a/django/templates/category_detail.html
+++ b/django/templates/category_detail.html
@@ -14,6 +14,7 @@
     </div>
     <p>カテゴリーの目標： <span id="category-goal"></span></p>
     <p>カテゴリーの累計時間： <span id="category-total-duration"></span></p>
+    <p>カテゴリーの累計日数： <span id="category_total_days"></span></p>
     <ul id="date-list"></ul>
     <ul id="duration-list"></ul>
 
@@ -28,6 +29,7 @@
             $('#category-info').css('background-color', data.color_code);
             $('#category-goal').text(data.goal);
             $('#category-total-duration').text(data.category_total_duration);
+            $('#category_total_days').text(data.category_total_days);
 
             const $dateList = $('#date-list');
             const $durationList = $('#duration-list');


### PR DESCRIPTION
## 目的
カテゴリー毎の累計日数のデータをJSONで渡す

## 実装の概要/やったこと
CategoryDetailAjaxViewにカテゴリー累計日数のデータを追加
カテゴリー累計時間の表示を「00：00」から「0：00」に変更

## 保留/やらないこと
なし

## できるようになること（ユーザ目線）
カテゴリー毎の累計日数を確認できる

## できなくなること（ユーザ目線）
なし

## 動作確認
カテゴリー毎のページで累計日数が表示されるのを確認
累計日数が登録データを差異がないか確認

## その他

- close #52 
- @dan-k4 
