### PR TITLE
カテゴリーを作成しても、カテゴリーに紐付けて記録をしないとカテゴリーリストが表示されなかった不具合の修正

### DIFF
--- a/django/categories/views.py
+++ b/django/categories/views.py
@@ -68,6 +68,10 @@ class CategoryDetailAjaxView(generic.DetailView):
         # カテゴリーに紐づくアクティビティの合計時間を取得
         activities = ActivityRecord.objects.filter(activitycategory__category=category)
         total_duration = activities.aggregate(total_duration=Sum('duration'))['total_duration']
+
+        #  total_durationがNoneの場合は0に設定する
+        total_duration = total_duration if total_duration is not None else 0
+
         activity_duration_dict = activities.annotate(day=Sum('duration')).values('day', 'date')
         activity_duration_dict = {activity['date']: activity['day'] for activity in activity_duration_dict}
 

--- a/django/categories/views.py
+++ b/django/categories/views.py
@@ -8,16 +8,16 @@ from .models import Category
 from .forms import CategoryForm
 from datetime import timedelta, datetime
 from activity.models import ActivityRecord
-from django.db.models import Sum
-from django.db.models import Q
+from django.db.models import Sum, Value
+from django.db.models.functions import Coalesce
 
 # Categoryの情報をJSON形式で返すView
 class CategoryHomeAjaxView(generic.View):
     def get(self, request, *args, **kwargs):
         # ユーザーが作成したカテゴリーの一覧を取得
         categories = Category.objects.filter(user=request.user, is_deleted=False).annotate(
-            total_duration=Sum('activitycategory__activity_record__duration')  # カテゴリーの総時間を計算
-        ).exclude(Q(activitycategory__activity_record__duration=None) | Q(total_duration=None))
+            total_duration=Coalesce(Sum('activitycategory__activity_record__duration'), Value(0))
+        )
 
         # カテゴリーの情報を辞書型で保存
         categories_data = [
@@ -48,6 +48,7 @@ class CategoryDetailView(LoginRequiredMixin, generic.DetailView):
 # カテゴリー毎の詳細画面へJson型のデータを送信する(非同期通信)
 class CategoryDetailAjaxView(generic.DetailView):
     model = Category
+    template_name = None
 
     def get(self, request, *args, **kwargs):
         # カテゴリーの基本情報を取得

--- a/django/static/admin/js/categories_list.js
+++ b/django/static/admin/js/categories_list.js
@@ -23,6 +23,7 @@
    // データが存在する場合
    categories.forEach(category => {
     // 新しいdiv要素を作成
+    console.log(category);
     const categoryElement = document.createElement("div");
     // 作成したdiv要素にCSSクラスを設定
     categoryElement.className = `category bg-${category.color_code} text-textBlack rounded-lg p-4 w-64 h-12 flex justify-between items-center mb-4`;


### PR DESCRIPTION
## 目的
- カテゴリー作成のみでは、ホーム画面にカテゴリー名が表示されない不具合の修正

## 実装の概要/やったこと
- カテゴリーリストをホーム画面に送信する際に、total_durationが0の場合でも送信するように修正
- カテゴリー詳細画面に遷移した際に、total_durationがNoneの場合は0に置き換えるように設定

## 保留/やらないこと
- なし

## できるようになること（ユーザ目線）
- なし

## できなくなること（ユーザ目線）
- なし

## 動作確認

- ブラウザでの表示確認

## その他
close #69 
@mappii130 
