### PR TITLE
一度submitされたらボタンを無効化

### DIFF
--- a/django/static/admin/js/activity_add.js
+++ b/django/static/admin/js/activity_add.js
@@ -16,6 +16,10 @@ document.getElementById("close-modal").addEventListener("click", function () {
 // フォームの送信後、エラーもしくは、データを取得してからモーダル出力する流れ。（バックエンドで記載していたもの）
 
 async function submitForm() {
+  // #65 5/22 サブミットボタン複数回押下を止める処理を追加します。
+  const submitButton = document.getElementById("recordSubmit");
+  // console.log(submitButton);
+  submitButton.disabled = true;
   // フォームデータを取得
   const formData = new FormData(document.querySelector("#activityRecordForm"));
 

--- a/django/templates/activity_add.html
+++ b/django/templates/activity_add.html
@@ -69,7 +69,7 @@ bg-snow text-textBlack font-NotoSans
 
   <!-- 送信ボタンを追加 -->
   <div class="text-center">
-    <button type="submit" class="flex justify-center mx-auto btn-blackGreen text-textBlack h-10 w-40 p-2 rounded mt-4">
+    <button type="submit" class="flex justify-center mx-auto btn-blackGreen text-textBlack h-10 w-40 p-2 rounded mt-4" id="recordSubmit">
       積み上げを記録する
     </button>
   </div>


### PR DESCRIPTION
## 目的
- 複数回ボタンが押されて処理が走る問題の解決

## 実装の概要/やったこと

- 複数回データが登録されないよう、ボタンを一度押したら無効化する

## 保留/やらないこと

- なし

## できるようになること（ユーザ目線）

- Nothing

## できなくなること（ユーザ目線）

- 梨

## 動作確認

- 依然として1度クリックは可能

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #65 
- @dan-k4 
