### PR TITLE
‘カテゴリー追加・編集ページに名前重複モーダルの追加’

### DIFF
--- a/django/templates/category_add.html
+++ b/django/templates/category_add.html
@@ -76,20 +76,32 @@ bg-snow text-textBlack font-NotoSans
 {% comment %} 以下はモーダル画面。バックエンドが記載したもの。別のissueでコーディング予定。 {% endcomment %}
 
 
-{# モーダル for deleted category #}
-<div id="restoreContainer" style="display: none">
- <p>過去に同じカテゴリーを作成したことがあるようです。カテゴリーを引き継ぎますか？</p>
- <button id="restoreCategory">復元・引き継ぎ</button>
- <button id="createNewCategory">新しくカテゴリーを作成</button>
-</div>
+{% comment %} カテゴリー重複モーダル {% endcomment %}
+<div id="restoreContainer" style="display:none" class="fixed top-0 left-0 w-full h-full bg-black bg-opacity-50 z-50">
+  <!-- モーダルの背景（見えてる部分） -->
+  <div class="bg-white w-11/12 h-1/3 md:max-w-md mx-auto rounded shadow-lg p-6 mt-20 relative">
+   <p class="text-center mt-8">過去に同じカテゴリーを作成したことがあるようです。カテゴリーを引き継ぎますか？</p>
+   <div class="flex justify-center mt-8 space-x-4">
+    {% comment %} 書くボタンにバックエンドに合わせてidを足した。 {% endcomment %}
+    <button class="bg-orangerange text-white px-4 py-2 rounded" id="restoreCategory">復元・引き継ぎ</button>
+    <button class="bg-orangerange text-white px-4 py-2 rounded" id="createNewCategory">新しくカテゴリーを作成</button>
+   </div>
+  </div>
+ </div>
 
-{# モーダル for existing category #}
-<div id="existingContainer" style="display: none">
- <p>既に同じ名前のカテゴリーが存在するようです。カテゴリーを作成しますか？</p>
- <button id="createNewCategoryForExisting">はい</button>
- <button id="cancelNewCategoryForExisting">キャンセル</button>
-</div>
 
+ {% comment %} カテゴリー既存モーダル {% endcomment %}
+<div id="existingContainer" style="display:none" class="fixed top-0 left-0 w-full h-full bg-black bg-opacity-50 z-50">
+  <!-- モーダルの背景（見えてる部分） -->
+  <div class="bg-white w-11/12 h-1/3 md:max-w-md mx-auto rounded shadow-lg p-6 mt-20 relative">
+   <p class="text-center mt-8">既に同じ名前のカテゴリーが存在するようです。カテゴリーを作成しますか？</p>
+   <div class="flex justify-center mt-8 space-x-4">
+    {% comment %} 書くボタンにバックエンドに合わせてidを足した。 {% endcomment %}
+    <button class="bg-orangerange text-white px-4 py-2 rounded" id="createNewCategoryForExisting">はい</button>
+    <button class="bg-orangerange text-white px-4 py-2 rounded" id="cancelNewCategoryForExisting">キャンセル</button>
+   </div>
+  </div>
+ </div>
 <script>
  document.getElementById("categoryAddForm").addEventListener("submit", function (event) {
   event.preventDefault();

--- a/django/templates/category_edit.html
+++ b/django/templates/category_edit.html
@@ -17,7 +17,7 @@ bg-snow text-textBlack font-NotoSans
  <nav class="text-lg">
   <a href="{% url 'activity:home' %}" class="hover:underline text-#474747">ホーム</a>
   <span> &gt; </span>
-  <span>カテゴリー追加</span>
+  <span>カテゴリー編集</span>
  </nav>
 </div>
 
@@ -69,10 +69,11 @@ bg-snow text-textBlack font-NotoSans
   </form>
 </div>
 
-<!-- モーダルの背景。普段はdisplay:noneでblockにして表示する。 -->
-<div id="existingContaine" style="display:none" class="fixed top-0 left-0 w-full h-full bg-black bg-opacity-50 z-50">
+
+ {% comment %} カテゴリー既存モーダル {% endcomment %}
+<div id="existingContainer" style="display:none" class="fixed top-0 left-0 w-full h-full bg-black bg-opacity-50 z-50">
   <!-- モーダルの背景（見えてる部分） -->
-  <div class="bg-white w-11/12 h-2/3 md:max-w-md mx-auto rounded shadow-lg p-6 mt-20 relative">
+  <div class="bg-white w-11/12 h-1/3 md:max-w-md mx-auto rounded shadow-lg p-6 mt-20 relative">
    <p class="text-center mt-8">既に同じ名前のカテゴリーが存在するようです。カテゴリーを編集しますか？</p>
    <div class="flex justify-center mt-8 space-x-4">
     {% comment %} 書くボタンにバックエンドに合わせてidを足した。 {% endcomment %}
@@ -81,16 +82,6 @@ bg-snow text-textBlack font-NotoSans
    </div>
   </div>
  </div>
-
-
- {% comment %} 念の為に取っておく。バッグエンドが記載した文 {% endcomment %}
-  {% comment %} {# モーダル for existing category #}
-  <div id="existingContainer" style="display:none;">
-    <p>既に同じ名前のカテゴリーが存在するようです。カテゴリーを編集しますか？</p>
-    <button id="createNewCategoryForExisting">はい</button>
-    <button id="cancelNewCategoryForExisting">キャンセル</button>
-  </div> {% endcomment %}
-
 
 {% comment %} 存在するカテゴリー用モーダル {% endcomment %}
 <script src="{% static 'admin/js/existing_edit.js' %}"></script>


### PR DESCRIPTION
## 目的
-カテゴリー追加・編集ページに名前重複モーダルの追加

## 実装の概要/やったこと

- カテゴリー追加・編集ページに名前重複モーダルの追加しました。

## 保留/やらないこと

-カテゴリー編集の方のテストは行えていない

## できるようになること（ユーザ目線）

- 重複した名前のカテゴリーを作成しようとするとモーダルが表示されるようになりました。

## できなくなること（ユーザ目線）

- 特になし

## 動作確認

- 追加ページの方は本番環境で確認を行いました。

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #72 
- @hiroki-rr 
