### PR TITLE
カテゴリー詳細ページからカテゴリー編集ページへ遷移&カテゴリー編集ページの作成(優先度高) 

### DIFF
--- a/django/templates/category_add.html
+++ b/django/templates/category_add.html
@@ -76,20 +76,32 @@ bg-snow text-textBlack font-NotoSans
 {% comment %} 以下はモーダル画面。バックエンドが記載したもの。別のissueでコーディング予定。 {% endcomment %}
 
 
-{# モーダル for deleted category #}
-<div id="restoreContainer" style="display: none">
- <p>過去に同じカテゴリーを作成したことがあるようです。カテゴリーを引き継ぎますか？</p>
- <button id="restoreCategory">復元・引き継ぎ</button>
- <button id="createNewCategory">新しくカテゴリーを作成</button>
-</div>
+{% comment %} カテゴリー重複モーダル {% endcomment %}
+<div id="restoreContainer" style="display:none" class="fixed top-0 left-0 w-full h-full bg-black bg-opacity-50 z-50">
+  <!-- モーダルの背景（見えてる部分） -->
+  <div class="bg-white w-11/12 h-1/3 md:max-w-md mx-auto rounded shadow-lg p-6 mt-20 relative">
+   <p class="text-center mt-8">過去に同じカテゴリーを作成したことがあるようです。カテゴリーを引き継ぎますか？</p>
+   <div class="flex justify-center mt-8 space-x-4">
+    {% comment %} 書くボタンにバックエンドに合わせてidを足した。 {% endcomment %}
+    <button class="bg-orangerange text-white px-4 py-2 rounded" id="restoreCategory">復元・引き継ぎ</button>
+    <button class="bg-orangerange text-white px-4 py-2 rounded" id="createNewCategory">新しくカテゴリーを作成</button>
+   </div>
+  </div>
+ </div>
 
-{# モーダル for existing category #}
-<div id="existingContainer" style="display: none">
- <p>既に同じ名前のカテゴリーが存在するようです。カテゴリーを作成しますか？</p>
- <button id="createNewCategoryForExisting">はい</button>
- <button id="cancelNewCategoryForExisting">キャンセル</button>
-</div>
 
+ {% comment %} カテゴリー既存モーダル {% endcomment %}
+<div id="existingContainer" style="display:none" class="fixed top-0 left-0 w-full h-full bg-black bg-opacity-50 z-50">
+  <!-- モーダルの背景（見えてる部分） -->
+  <div class="bg-white w-11/12 h-1/3 md:max-w-md mx-auto rounded shadow-lg p-6 mt-20 relative">
+   <p class="text-center mt-8">既に同じ名前のカテゴリーが存在するようです。カテゴリーを作成しますか？</p>
+   <div class="flex justify-center mt-8 space-x-4">
+    {% comment %} 書くボタンにバックエンドに合わせてidを足した。 {% endcomment %}
+    <button class="bg-orangerange text-white px-4 py-2 rounded" id="createNewCategoryForExisting">はい</button>
+    <button class="bg-orangerange text-white px-4 py-2 rounded" id="cancelNewCategoryForExisting">キャンセル</button>
+   </div>
+  </div>
+ </div>
 <script>
  document.getElementById("categoryAddForm").addEventListener("submit", function (event) {
   event.preventDefault();

--- a/django/templates/category_detail.html
+++ b/django/templates/category_detail.html
@@ -28,7 +28,10 @@ bg-snow text-textBlack font-NotoSans
  </div>
 
 <!-- タイトルにカテゴリーの色、名前、目標を載せる -->
-<div id="category-info" class="container mx-auto px-4 sm:px-6 lg:px-8 flex flex-col items-center">
+<div id="category-info" class="container mx-auto px-4 sm:px-6 lg:px-8 flex flex-col">
+  <p class="pt-4 text-xs md:text-base text-textBlack hover:text-white cursor-pointer text-left"
+  onclick="window.location.href='{% url 'categories:category_edit' pk=category.id %}'"
+  > ＜カテゴリーを編集する＞</p>
   <h1 id="category-name" class="pt-4 text-center text-xl md:text-3xl text-textBlack"></h1>
   <span id="category-goal" class="pt-4 text-center text-sm md:text-base text-textBlack"></span>
 </div>

--- a/django/templates/category_edit.html
+++ b/django/templates/category_edit.html
@@ -17,7 +17,7 @@ bg-snow text-textBlack font-NotoSans
  <nav class="text-lg">
   <a href="{% url 'activity:home' %}" class="hover:underline text-#474747">ホーム</a>
   <span> &gt; </span>
-  <span>カテゴリー追加</span>
+  <span>カテゴリー編集</span>
  </nav>
 </div>
 
@@ -69,10 +69,11 @@ bg-snow text-textBlack font-NotoSans
   </form>
 </div>
 
-<!-- モーダルの背景。普段はdisplay:noneでblockにして表示する。 -->
-<div id="existingContaine" style="display:none" class="fixed top-0 left-0 w-full h-full bg-black bg-opacity-50 z-50">
+
+ {% comment %} カテゴリー既存モーダル {% endcomment %}
+<div id="existingContainer" style="display:none" class="fixed top-0 left-0 w-full h-full bg-black bg-opacity-50 z-50">
   <!-- モーダルの背景（見えてる部分） -->
-  <div class="bg-white w-11/12 h-2/3 md:max-w-md mx-auto rounded shadow-lg p-6 mt-20 relative">
+  <div class="bg-white w-11/12 h-1/3 md:max-w-md mx-auto rounded shadow-lg p-6 mt-20 relative">
    <p class="text-center mt-8">既に同じ名前のカテゴリーが存在するようです。カテゴリーを編集しますか？</p>
    <div class="flex justify-center mt-8 space-x-4">
     {% comment %} 書くボタンにバックエンドに合わせてidを足した。 {% endcomment %}
@@ -81,16 +82,6 @@ bg-snow text-textBlack font-NotoSans
    </div>
   </div>
  </div>
-
-
- {% comment %} 念の為に取っておく。バッグエンドが記載した文 {% endcomment %}
-  {% comment %} {# モーダル for existing category #}
-  <div id="existingContainer" style="display:none;">
-    <p>既に同じ名前のカテゴリーが存在するようです。カテゴリーを編集しますか？</p>
-    <button id="createNewCategoryForExisting">はい</button>
-    <button id="cancelNewCategoryForExisting">キャンセル</button>
-  </div> {% endcomment %}
-
 
 {% comment %} 存在するカテゴリー用モーダル {% endcomment %}
 <script src="{% static 'admin/js/existing_edit.js' %}"></script>

--- a/django/templates/category_edit.html
+++ b/django/templates/category_edit.html
@@ -83,9 +83,52 @@ bg-snow text-textBlack font-NotoSans
   </div>
  </div>
 
-{% comment %} 存在するカテゴリー用モーダル {% endcomment %}
-<script src="{% static 'admin/js/existing_edit.js' %}"></script>
-
+ <script>
+  document.getElementById("categoryAddForm").addEventListener("submit", function (event) {
+   event.preventDefault();
+ 
+   let categoryName = document.getElementsByName("name")[0].value;
+   let formData = new FormData(event.target);
+ 
+   fetch("{% url 'categories:check_duplicate_add' %}", {
+    method: "POST",
+    body: JSON.stringify({ name: categoryName }),
+    headers: {
+     "Content-Type": "application/json",
+     "X-CSRFToken": "{{ csrf_token }}"
+    }
+   })
+    .then(response => response.json())
+    .then(data => {
+     if (data.duplicate) {
+      if (data.category_id !== null) {
+       // 削除されたカテゴリーと同じ名前の場合 (is_deleted = true)
+       document.getElementById("restoreContainer").style.display = "block";
+       let categoryId = data.category_id;
+       document.getElementById("restoreCategory").onclick = function () {
+        location.href = "{% url 'categories:category_restore' 0 %}".replace("0", categoryId);
+       };
+       document.getElementById("createNewCategory").onclick = function () {
+        event.target.submit();
+       };
+      } else {
+       // 既に存在するカテゴリーと同じ名前の場合 (is_deleted = false)
+       document.getElementById("existingContainer").style.display = "block";
+       document.getElementById("createNewCategoryForExisting").onclick = function () {
+        event.target.submit();
+       };
+       document.getElementById("cancelNewCategoryForExisting").onclick = function () {
+        document.getElementById("existingContainer").style.display = "none";
+       };
+      }
+     } else {
+      // 同じ名前のカテゴリーが存在しない場合
+      event.target.submit();
+     }
+    });
+  });
+ </script>
+ 
 {% comment %} クリップボード保存機能を持たせている。 {% endcomment %}
 <script src="{% static 'admin/js/category_add.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## 目的
-カテゴリー詳細ページからカテゴリー編集ページへ遷移&カテゴリー編集ページの作成(優先度高) 

## 実装の概要/やったこと

- category_detail.htmlに編集ページへのリンクを作成。
- category_edit.htmlのバグ修正（モーダルの表示）

## 保留/やらないこと

- なし

## できるようになること（ユーザ目線）

- カテゴリー編集ページに飛べるようになりました

## できなくなること（ユーザ目線）

- なし

## 動作確認

- 本番環境で実行しました。

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #70 
- @hiroki-rr 
