### PR TITLE
[優先度中](ホーム画面)カテゴリー削除後、グラフに削除したカテゴリーを表示しない

### DIFF
--- a/django/activity/views.py
+++ b/django/activity/views.py
@@ -31,8 +31,8 @@ class HomeAjaxView(LoginRequiredMixin, generic.View):
 
         # request.userを使用して現在のユーザーに紐づくアクティビティ記録を取得
         # date__gte=end_dateは、日付がend_dateよりも大きいまたは等しい記録のみを取得するフィルター
-        # prefetchを用いてactivityに関連するカテゴリーを先に全て取得
-        activity_categories = ActivityCategory.objects.all()
+        # 'category__is_deleted=False'を追加して、削除されていないカテゴリーに関連するActivityCategoryのみを取得
+        activity_categories = ActivityCategory.objects.filter(category__is_deleted=False)
         records = ActivityRecord.objects.filter(user=self.request.user, date__gte=end_date).prefetch_related(Prefetch('activitycategory_set', queryset=activity_categories))
 
         # 全てのカテゴリーを取得
@@ -176,10 +176,11 @@ class ActivityListAjaxView(LoginRequiredMixin, generic.View):
 
         # アクティビティに紐づくカテゴリーを一括で取得 (N+1問題の解消)
         # prefetch_relatedを使って、ActivityCategoryとCategoryを一度に取得
+        # 'category__is_deleted=False'を追加して、削除されていないカテゴリーに関連するActivityCategoryのみを取得
         activities = activities.prefetch_related(
             Prefetch(
                 'activitycategory_set',
-                queryset=ActivityCategory.objects.select_related('category'),
+                queryset=ActivityCategory.objects.filter(category__is_deleted=False).select_related('category'),
                 to_attr='fetched_categories'
             )
         )


### PR DESCRIPTION
## 目的
- カテゴリーを削除した場合、そのカテゴリーの表示を削除する

## 実装の概要/やったこと
- カテゴリーを削除した場合のホーム画面のグラフ表示を削除(ActivityHomeAjaxView)
- カテゴリーを削除した場合の積み上げ一覧画面の表示を削除(ActivityListAjaxView)

## 保留/やらないこと
- なし

## できるようになること（ユーザ目線）
- なし

## できなくなること（ユーザ目線）
- 削除したカテゴリーの積み上げの確認

## 動作確認
- ブラウザで表示確認

## その他
- 前に工数とクエリ数を考慮して、表示する方向で決めましたが時間ができたのと、クエリ数がprefetchを使用することで解決できることが判明したので表示のみ消すように設定してみました。一応実装しましたが、表示した方がよければマージせずに一旦プルリクのcloseしてもらって大丈夫です。
- close #82 
- @mappii130 
