### PR TITLE
[優先度中](積み上げ記録一覧画面)表示順をcreated_atへ変更

### DIFF
--- a/django/activity/views.py
+++ b/django/activity/views.py
@@ -172,7 +172,7 @@ class ActivityListAjaxView(LoginRequiredMixin, generic.View):
     # getリクエストの処理
     def get(self, request, *args, **kwargs):
         # ユーザーのアクティビティレコードを取得
-        activities = ActivityRecord.objects.filter(user=request.user)
+        activities = ActivityRecord.objects.filter(user=request.user).order_by('-created_at')
 
         # アクティビティに紐づくカテゴリーを一括で取得 (N+1問題の解消)
         # prefetch_relatedを使って、ActivityCategoryとCategoryを一度に取得


### PR DESCRIPTION
## 目的
- 積み上げ記録一覧画面の表示順をcreated_atへ変更

## 実装の概要/やったこと
- activitylistajaxview内で積み上げ記録一覧画面の表示順をcreated_atへ変更

## 保留/やらないこと
- なし

## できるようになること（ユーザ目線）
- なし

## できなくなること（ユーザ目線）
- なし

## 動作確認
- ブラウザでの表示確認

## その他
- updated_atではなくcreated_atとしていますが、どっちの方が使いやすいですかね？
- close #85 
- @mappii130 
