### PR TITLE
色の入力を不可に、ボタンを押すと枠＋サンプルを大きく

### DIFF
--- a/django/static/admin/js/category_add.js
+++ b/django/static/admin/js/category_add.js
@@ -22,3 +22,16 @@ function copyToClipboard(colorCode) {
     document.getElementById("id_color_code").value = colorCode;
     document.getElementById("color-circle").style.backgroundColor = colorCode;
 }
+
+
+// ボタンのクリックを処理する関数
+function handleButtonClick(event) {
+    // すべてのボタンからボーダーを削除
+    var buttons = document.querySelectorAll('.color-button');
+    for (var i = 0; i < buttons.length; i++) {
+      buttons[i].style.border = '';
+    }
+  
+    // クリックしたボタンにボーダーを追加
+    event.target.style.border = '5px solid white';
+  }

--- a/django/templates/category_add.html
+++ b/django/templates/category_add.html
@@ -70,13 +70,13 @@ bg-snow text-textBlack font-NotoSans
 
           <!-- 色の選択。押したらクリップボードにコピーされる -->
         <div class="flex flex-wrap justify-center space-x-4">
-          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#DAD4B7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#DAD4B7')"></div>
-          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#B7C1DA] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#B7C1DA')"></div>
-          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#DABEB7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#DABEB7')"></div>
-          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#DAC6B7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#DAC6B7')"></div>
-          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#CFB7DA] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#CFB7DA')"></div>
-          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#B7D6DA] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#B7D6DA')"></div>
-          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#C6DAB7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#C6DAB7')"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#DAD4B7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs color-button" onclick="copyToClipboard('#DAD4B7'); handleButtonClick(event)"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#B7C1DA] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs color-button" onclick="copyToClipboard('#B7C1DA'); handleButtonClick(event)"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#DABEB7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs color-button" onclick="copyToClipboard('#DABEB7'); handleButtonClick(event)"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#DAC6B7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs color-button" onclick="copyToClipboard('#DAC6B7'); handleButtonClick(event)"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#CFB7DA] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs color-button" onclick="copyToClipboard('#CFB7DA'); handleButtonClick(event)"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#B7D6DA] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs color-button" onclick="copyToClipboard('#B7D6DA'); handleButtonClick(event)"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#C6DAB7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs color-button" onclick="copyToClipboard('#C6DAB7'); handleButtonClick(event)"></div>
         </div>
 
 

--- a/django/templates/category_add.html
+++ b/django/templates/category_add.html
@@ -48,27 +48,36 @@ bg-snow text-textBlack font-NotoSans
      {{ form.color_code }}
    </div> -->
    <!-- カラーの選択 -->
-  <div class="mx-auto w-full md:w-3/4 py-2 bg-blackGreen text-textBlack rounded-lg flex items-center justify-center">
-    {{ form.color_code.label_tag }}
-
-    {{ form.color_code }}
-
-    <div class="color-sample" style="display: flex; align-items: center; margin-left: 10px;">
-      <div id="color-circle" style="width: 20px; height: 20px; border-radius: 50%; margin-right: 5px;"></div>
-    </div>
-  </div>
-
-
-        <!-- 色の選択。押したらクリップボードにコピーされる -->
-      <div class="flex flex-wrap justify-center space-x-4">
-        <div class="w-16 h-16 md:w-16 md:h-16 bg-[#DAD4B7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#DAD4B7')"></div>
-        <div class="w-16 h-16 md:w-16 md:h-16 bg-[#B7C1DA] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#B7C1DA')"></div>
-        <div class="w-16 h-16 md:w-16 md:h-16 bg-[#DABEB7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#DABEB7')"></div>
-        <div class="w-16 h-16 md:w-16 md:h-16 bg-[#DAC6B7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#DAC6B7')"></div>
-        <div class="w-16 h-16 md:w-16 md:h-16 bg-[#CFB7DA] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#CFB7DA')"></div>
-        <div class="w-16 h-16 md:w-16 md:h-16 bg-[#B7D6DA] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#B7D6DA')"></div>
-        <div class="w-16 h-16 md:w-16 md:h-16 bg-[#C6DAB7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#C6DAB7')"></div>
+   <div class="mx-auto w-full md:w-3/4 py-2 bg-blackGreen text-textBlack rounded-lg flex items-center justify-center">
+    <div style="display: flex; align-items: center; justify-content: center; width: 100%;">
+      <label for="id_color_code" class="pr-2">Color:</label> <!-- margin-rightを削除し、justify-content: center;を追加 -->
+      <div class="color-sample">
+        <div id="color-circle" style="width: 160px; height: 25px;"></div> <!-- border-radiusを削除して四角形にする -->
       </div>
+    </div>
+    <div style="display: none;">
+      {{ form.color_code.label_tag }}
+      {{ form.color_code }}
+    </div>
+  </div>  
+  
+
+    <!-- <div class="color-sample" style="display: flex; align-items: center; margin-left: 10px;">
+      <div id="color-circle" style="width: 100px; height: 20px; border-radius: 10px; margin-right: 5px;"></div>
+    </div>    
+  </div> -->
+
+
+          <!-- 色の選択。押したらクリップボードにコピーされる -->
+        <div class="flex flex-wrap justify-center space-x-4">
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#DAD4B7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#DAD4B7')"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#B7C1DA] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#B7C1DA')"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#DABEB7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#DABEB7')"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#DAC6B7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#DAC6B7')"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#CFB7DA] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#CFB7DA')"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#B7D6DA] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#B7D6DA')"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#C6DAB7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#C6DAB7')"></div>
+        </div>
 
 
 


### PR DESCRIPTION
## 目的
- 色を自由に入力できなくする

## 実装の概要/やったこと

- input欄の見えない化と、ボタンを押した際に元々inputがあった箇所にサンプルカラーが表示されるように
- ボタンを押した際にボーダーで囲って何を選択したかがわかりやすく

## 保留/やらないこと

- なし

## できるようになること（ユーザ目線）

- ボタンで選んだ色がわかりやすくなる

## できなくなること（ユーザ目線）

- 自由にカラーコードを入れることができなくなる

## 動作確認

- ボタン押した際の挙動

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #81
- @dan-k4 
