### PR TITLE
#67タイトル見切れ問題デスクトップのみ解決 / #89ヘッダー等の見出し統一

### DIFF
--- a/django/static/admin/js/category_add.js
+++ b/django/static/admin/js/category_add.js
@@ -22,3 +22,16 @@ function copyToClipboard(colorCode) {
     document.getElementById("id_color_code").value = colorCode;
     document.getElementById("color-circle").style.backgroundColor = colorCode;
 }
+
+
+// ボタンのクリックを処理する関数
+function handleButtonClick(event) {
+    // すべてのボタンからボーダーを削除
+    var buttons = document.querySelectorAll('.color-button');
+    for (var i = 0; i < buttons.length; i++) {
+      buttons[i].style.border = '';
+    }
+  
+    // クリックしたボタンにボーダーを追加
+    event.target.style.border = '5px solid white';
+  }

--- a/django/static/admin/js/category_add.js
+++ b/django/static/admin/js/category_add.js
@@ -27,8 +27,8 @@ function copyToClipboard(colorCode) {
 // ボタンのクリックを処理する関数
 function handleButtonClick(event) {
     // すべてのボタンからボーダーを削除
-    var buttons = document.querySelectorAll('.color-button');
-    for (var i = 0; i < buttons.length; i++) {
+    let buttons = document.querySelectorAll('.color-button');
+    for (let i = 0; i < buttons.length; i++) {
       buttons[i].style.border = '';
     }
   

--- a/django/templates/activity_add.html
+++ b/django/templates/activity_add.html
@@ -38,7 +38,7 @@ bg-snow text-textBlack font-NotoSans
     <div class="relative mx-auto w-1/2 h-14">
       <div class="absolute inset-0 bg-blackGreen rounded-lg"></div>
       <img src="{% static 'admin/img/pencil-icon.png' %}" alt="category icon" class="absolute left-4 top-1/2 transform -translate-y-1/2 h-6 w-6" />
-      <select id="category" name="{{ form.category.name }}" class="form-select block bg-gray-300 w-1/2 translate-x-1/2 translate-y-1/3 pl-16 pr-8 py-2 bg-transparent text-textBlack rounded-lg">
+      <select id="category" name="{{ form.category.name }}" class="form-select block bg-gray-300 w-3/4 translate-x-1/4 translate-y-1/3 pl-20 pr-8 py-2 bg-transparent text-textBlack rounded-lg" style="text-indent: 1.5em;">
         <!-- カテゴリーオプションの初期値指定 -->
         <option value="">カテゴリーを選択してください</option>
         <!-- カテゴリーオプションはformsからデータを取得 -->

--- a/django/templates/activity_add.html
+++ b/django/templates/activity_add.html
@@ -17,14 +17,14 @@ bg-snow text-textBlack font-NotoSans
   <nav class="text-lg">
    <a href="{% url 'activity:home' %}" class="hover:underline text-#474747">ホーム</a>
    <span> &gt; </span>
-   <span>アクティビティ追加</span>
+   <span>積み上げ記録</span>
   </nav>
  </div>
 
 
 <!-- タイトルの作成 -->
 <h1 class="container mx-auto px-4 pt-4 text-center bg-snow text-xl md:text-3xl text-textBlack">
-  アクティビティを追加する
+  積み上げを記録する 
  </h1>
  <hr class="mx-10 my-4 border-2 border-blackGreen shadow-md" />
 

--- a/django/templates/activity_list.html
+++ b/django/templates/activity_list.html
@@ -78,13 +78,13 @@ bg-snow text-textBlack font-NotoSans
   <nav class="text-lg">
    <a href="{% url 'activity:home' %}" class="hover:underline text-#474747">ホーム</a>
    <span> &gt; </span>
-   <span>アクティビティリスト</span>
+   <span>積み上げ一覧</span>
   </nav>
  </div>
 
 <!-- タイトルの作成 -->
 <h1 class="container mx-auto px-4 pt-4 text-center bg-snow text-xl md:text-3xl text-textBlack">
-  アクティビティ一覧
+  積み上げ一覧
  </h1>
  <hr class="mx-10 my-4 border-2 border-blackGreen shadow-md" />
 

--- a/django/templates/base.html
+++ b/django/templates/base.html
@@ -106,10 +106,10 @@
        <a href="{% url 'activity:home' %}" class="hover:underline">ホーム</a>
       </li>
       <li>
-       <a href="{% url 'activity:activity_list' %}" class="hover:underline">アクティビティ</a>
+       <a href="{% url 'activity:activity_list' %}" class="hover:underline">一覧</a>
       </li>
       <li>
-       <a href="{% url 'activity:activity_add' %}" class="hover:underline">記録画面</a>
+       <a href="{% url 'activity:activity_add' %}" class="hover:underline">記録</a>
       </li>
       <li>
        <a href="{% url 'categories:category_add' %}" class="hover:underline">カテゴリー追加</a>

--- a/django/templates/category_add.html
+++ b/django/templates/category_add.html
@@ -70,13 +70,13 @@ bg-snow text-textBlack font-NotoSans
 
           <!-- 色の選択。押したらクリップボードにコピーされる -->
         <div class="flex flex-wrap justify-center space-x-4">
-          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#DAD4B7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#DAD4B7')"></div>
-          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#B7C1DA] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#B7C1DA')"></div>
-          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#DABEB7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#DABEB7')"></div>
-          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#DAC6B7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#DAC6B7')"></div>
-          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#CFB7DA] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#CFB7DA')"></div>
-          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#B7D6DA] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#B7D6DA')"></div>
-          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#C6DAB7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#C6DAB7')"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#DAD4B7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs color-button" onclick="copyToClipboard('#DAD4B7'); handleButtonClick(event)"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#B7C1DA] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs color-button" onclick="copyToClipboard('#B7C1DA'); handleButtonClick(event)"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#DABEB7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs color-button" onclick="copyToClipboard('#DABEB7'); handleButtonClick(event)"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#DAC6B7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs color-button" onclick="copyToClipboard('#DAC6B7'); handleButtonClick(event)"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#CFB7DA] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs color-button" onclick="copyToClipboard('#CFB7DA'); handleButtonClick(event)"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#B7D6DA] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs color-button" onclick="copyToClipboard('#B7D6DA'); handleButtonClick(event)"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#C6DAB7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs color-button" onclick="copyToClipboard('#C6DAB7'); handleButtonClick(event)"></div>
         </div>
 
 

--- a/django/templates/category_add.html
+++ b/django/templates/category_add.html
@@ -48,27 +48,36 @@ bg-snow text-textBlack font-NotoSans
      {{ form.color_code }}
    </div> -->
    <!-- カラーの選択 -->
-  <div class="mx-auto w-full md:w-3/4 py-2 bg-blackGreen text-textBlack rounded-lg flex items-center justify-center">
-    {{ form.color_code.label_tag }}
-
-    {{ form.color_code }}
-
-    <div class="color-sample" style="display: flex; align-items: center; margin-left: 10px;">
-      <div id="color-circle" style="width: 20px; height: 20px; border-radius: 50%; margin-right: 5px;"></div>
-    </div>
-  </div>
-
-
-        <!-- 色の選択。押したらクリップボードにコピーされる -->
-      <div class="flex flex-wrap justify-center space-x-4">
-        <div class="w-16 h-16 md:w-16 md:h-16 bg-[#DAD4B7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#DAD4B7')"></div>
-        <div class="w-16 h-16 md:w-16 md:h-16 bg-[#B7C1DA] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#B7C1DA')"></div>
-        <div class="w-16 h-16 md:w-16 md:h-16 bg-[#DABEB7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#DABEB7')"></div>
-        <div class="w-16 h-16 md:w-16 md:h-16 bg-[#DAC6B7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#DAC6B7')"></div>
-        <div class="w-16 h-16 md:w-16 md:h-16 bg-[#CFB7DA] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#CFB7DA')"></div>
-        <div class="w-16 h-16 md:w-16 md:h-16 bg-[#B7D6DA] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#B7D6DA')"></div>
-        <div class="w-16 h-16 md:w-16 md:h-16 bg-[#C6DAB7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#C6DAB7')"></div>
+   <div class="mx-auto w-full md:w-3/4 py-2 bg-blackGreen text-textBlack rounded-lg flex items-center justify-center">
+    <div style="display: flex; align-items: center; justify-content: center; width: 100%;">
+      <label for="id_color_code" class="pr-2">Color:</label> <!-- margin-rightを削除し、justify-content: center;を追加 -->
+      <div class="color-sample">
+        <div id="color-circle" style="width: 160px; height: 25px;"></div> <!-- border-radiusを削除して四角形にする -->
       </div>
+    </div>
+    <div style="display: none;">
+      {{ form.color_code.label_tag }}
+      {{ form.color_code }}
+    </div>
+  </div>  
+  
+
+    <!-- <div class="color-sample" style="display: flex; align-items: center; margin-left: 10px;">
+      <div id="color-circle" style="width: 100px; height: 20px; border-radius: 10px; margin-right: 5px;"></div>
+    </div>    
+  </div> -->
+
+
+          <!-- 色の選択。押したらクリップボードにコピーされる -->
+        <div class="flex flex-wrap justify-center space-x-4">
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#DAD4B7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#DAD4B7')"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#B7C1DA] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#B7C1DA')"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#DABEB7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#DABEB7')"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#DAC6B7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#DAC6B7')"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#CFB7DA] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#CFB7DA')"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#B7D6DA] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#B7D6DA')"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#C6DAB7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#C6DAB7')"></div>
+        </div>
 
 
 


### PR DESCRIPTION
##  なぜか#81の色ボタンのコミット（２つあります）が混ざってしましました、、
　　さらにブランチ切り忘れてて、#67のタイトルが見切れる問題と#89の見出しの統一同時PRという状態になってます、、
　　すみません。わかりにくければMattermostで聞いてください。

## 見出しの統一 / カテゴリー入力が見切れる問題

## 実装の概要/やったこと

- 見出しの統一 / カテゴリー入力が見切れる問題をデスクトップのみで解決

## 保留/やらないこと

- レスポンシブは未対応

## できるようになること（ユーザ目線）

- カテゴリーを選択してくださいが全文字見えるように / 見出し（ヘッダー）などを統一

## できなくなること（ユーザ目線）

- なし

## 動作確認

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #67 #89 
- @dan-k4 
