### PR TITLE
[優先度高](積み上げ記録追加画面)エラー文にスタイルが当てられていない不具合の修正

### DIFF
--- a/django/static/admin/js/activity_add.js
+++ b/django/static/admin/js/activity_add.js
@@ -24,10 +24,10 @@ async function submitForm() {
   const formData = new FormData(document.querySelector("#activityRecordForm"));
 
     // 必須フィールドのチェック
-  if (!formData.get('date') || !formData.get('duration')) {
-    alert("時間と日付の入力は必須です");
-    return;
-  }
+  // if (!formData.get('date') || !formData.get('duration')) {
+  //   alert("時間と日付の入力は必須です");
+  //   return;
+  // }
 
   // 時間要素から入力された時間を取得し、分単位に変換
   const timeInput = document.querySelector('input[type="time"]');
@@ -65,7 +65,7 @@ async function submitForm() {
   showModal();
   } else {
   // エラーメッセージを表示またはログに記録
-  console.error(data.error);
+  console.error(totalDaysData.error);
   }
   } else {
   // フォーム送信のエラーメッセージを表示
@@ -80,40 +80,32 @@ async function submitForm() {
 
 // エラーメッセージを表示する関数
 function displayErrors(errors) {
- // エラーメッセージリストの要素を取得
- const errorMessageList = document.getElementById("errorMessageList");
- errorMessageList.innerHTML = "";
+  // エラーメッセージを表示する要素を取得
+  const dateErrors = document.getElementById("dateErrors");
+  const durationErrors = document.getElementById("durationErrors");
 
- // エラーメッセージをリストに追加
- for (const key in errors) {
-  if (Object.prototype.hasOwnProperty.call(errors, key)) {
-   const li = document.createElement("li");
-   li.textContent = errors[key];
-   errorMessageList.appendChild(li);
+  // エラーメッセージをクリア
+  dateErrors.innerHTML = "";
+  durationErrors.innerHTML = "";
+
+  // エラーメッセージを表示
+  for (const key in errors) {
+    if (Object.prototype.hasOwnProperty.call(errors, key)) {
+      const p = document.createElement("p");
+      const errorMsg = document.createTextNode(errors[key]);
+      p.style.marginTop = "0.8em"; // 上部のマージンを調整
+
+      p.appendChild(errorMsg);
+
+      if (key === "date") {
+        dateErrors.appendChild(p);
+        dateErrors.style.display = "block";
+      } else if (key === "duration") {
+        durationErrors.appendChild(p);
+        durationErrors.style.display = "block";
+      }
+    }
   }
- }
-
- // エラーメッセージを表示
- document.getElementById("errorMessages").style.display = "block";
-}
-
-// エラーメッセージを表示する関数
-function displayErrors(errors) {
- // エラーメッセージリストの要素を取得
- const errorMessageList = document.getElementById("errorMessageList");
- errorMessageList.innerHTML = "";
-
- // エラーメッセージをリストに追加
- for (const key in errors) {
-  if (Object.prototype.hasOwnProperty.call(errors, key)) {
-   const li = document.createElement("li");
-   li.textContent = errors[key];
-   errorMessageList.appendChild(li);
-  }
- }
-
- // エラーメッセージを表示
- document.getElementById("errorMessages").style.display = "block";
 }
 
 // ホームボタンのイベントリスナー

--- a/django/templates/activity_add.html
+++ b/django/templates/activity_add.html
@@ -53,14 +53,19 @@ bg-snow text-textBlack font-NotoSans
       <div class="absolute inset-0 bg-blackGreen rounded-lg"></div>
       <img src="{% static 'admin/img/calendar-icon.png' %}" alt="calendar icon" class="absolute left-4 top-1/2 transform -translate-y-1/2 h-6 w-6" />
       <input type="date" id="date" name="{{ form.date.name }}" class="block bg-gray-300 w-1/2 translate-x-1/2 translate-y-1/4 pl-16 pr-8 py-2 bg-transparent text-textBlack rounded-lg" value="今日の日付" />
-  </div>
+      <div id="dateErrors" class="text-red-500 error-messages" style="display: none;"></div>
+    </div>
 
   <!-- 時間選択フォーム -->
   <div class="relative mx-auto w-1/2 h-14">
       <div class="absolute inset-0 bg-blackGreen rounded-lg"></div>
       <img src="{% static 'admin/img/clock-icon.png' %}" alt="clock icon" class="absolute left-4 top-1/2 transform -translate-y-1/2 h-6 w-6" />
       <input type="time" id="duration" name="{{ form.duration.name }}" class="block bg-gray-300 w-1/2 translate-x-1/2 translate-y-1/4 pl-16 pr-8 py-2 bg-transparent text-textBlack rounded-lg" value="00:00" />
+      <div id="durationErrors" class="text-red-500 error-messages" style="display: none;"></div>
   </div>
+
+  <!-- エラーメッセージを表示する要素 -->
+<div id="durationErrors" class="text-red-500"></div>
 
   <!-- メモの入力フォーム。小さくなったときのリサイズはまた後日。 -->
   <div class="bg-white w-7/12 mx-auto p-6 rounded shadow relative">
@@ -125,10 +130,10 @@ bg-snow text-textBlack font-NotoSans
 
 
   {# Error messages #}
-  <div id="errorMessages" style="display: none;">
+  {% comment %} <div id="errorMessages" style="display: none;">
     <ul id="errorMessageList">
     </ul>
-  </div>
+  </div> {% endcomment %}
 
 
 <script src="{% static 'admin/js/activity_add.js' %}"></script>


### PR DESCRIPTION
## 目的
-(積み上げ記録追加画面)エラー文にスタイルが当てられていない不具合の修正

## 実装の概要/やったこと
- 各フォーム直下にエラー文が表示されるよう修正

## 保留/やらないこと
- なし

## できるようになること（ユーザ目線）
- 入力エラーの確認ができる

## できなくなること（ユーザ目線）
- なし

## 動作確認

- エラー文が出るか確認

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #64 
- @dan-k4 
