### PR TITLE
[優先度高](実績画面)比較条件がおかしい問題の修正 と 表示がわかりやすいように変更

### DIFF
--- a/django/badges/models.py
+++ b/django/badges/models.py
@@ -22,18 +22,18 @@ class Badge(models.Model):
         ('total_activities', '累計積み上げ数'),
     ]
     COMPARATORS = [
-        ('<', 'より大きい'),
-        ('>', 'より小さい'),
-        ('=', '等しい'),
-        ('<=', '以上'),
-        ('>=', '以下'),
+        ('<', 'より小さい'),
+        ('>', 'より大きい'),
+        ('==', '等しい'),
+        ('<=', '以下'),
+        ('>=', '以上'),
     ]
     name = models.CharField(max_length=255, null=False, blank=False)
     description = models.TextField(null=False, blank=False)
     badge_type = models.CharField(max_length=255, choices=BadgeType.BADGE_TYPES, null=False, blank=False)
     condition_type = models.CharField(max_length=255, choices=CONDITION_TYPES, null=False, blank=False)
     condition_value = models.IntegerField(null=False, blank=False)
-    comparator = models.CharField(max_length=2, choices=COMPARATORS, default='<=',null=False, blank=False)
+    comparator = models.CharField(max_length=2, choices=COMPARATORS, default='>=',null=False, blank=False)
     is_available = models.BooleanField(default=True)
 
     def __str__(self):

--- a/django/badges/views.py
+++ b/django/badges/views.py
@@ -96,7 +96,7 @@ class BadgeListAjaxView(LoginRequiredMixin, generic.View):
                 "badge_type": ub.badge.badge_type,
                 "color_code": BadgeType.objects.get(badge_type=ub.badge.badge_type).color_code,
                 "is_unlocked": True,  # ユーザーが獲得したため、is_unlockedはTrueです。
-                "date_unlocked": ub.date_unlocked.strftime('%Y/%m/%d')  # 獲得した日付
+                "date_unlocked": ub.date_unlocked.strftime('%Y/%-m/%-d')  # 獲得した日付
                 }
             for ub in user_badges
         ]

--- a/django/badges/views.py
+++ b/django/badges/views.py
@@ -96,7 +96,7 @@ class BadgeListAjaxView(LoginRequiredMixin, generic.View):
                 "badge_type": ub.badge.badge_type,
                 "color_code": BadgeType.objects.get(badge_type=ub.badge.badge_type).color_code,
                 "is_unlocked": True,  # ユーザーが獲得したため、is_unlockedはTrueです。
-                "date_unlocked": ub.date_unlocked  # 獲得した日付
+                "date_unlocked": ub.date_unlocked.strftime('%Y/%m/%d')  # 獲得した日付
                 }
             for ub in user_badges
         ]

--- a/django/badges/views.py
+++ b/django/badges/views.py
@@ -10,10 +10,12 @@ from django.http import JsonResponse
 
 # ユーザーの累計時間を取得し、指定した条件値と比較する関数
 def check_total_duration(user, condition_value, comparator):
-    # ユーザーの全ての活動レコードから累計時間を合計します
-    total_duration = ActivityRecord.objects.filter(user=user).aggregate(Sum('duration'))['duration__sum']
-    # 合計時間と条件値を指定した比較演算子で比較します
-    return compare_values(total_duration, condition_value, comparator)
+    # ユーザーの全ての活動レコードから累計時間（分）を合計します
+    total_duration_minutes = ActivityRecord.objects.filter(user=user).aggregate(Sum('duration'))['duration__sum']
+    # 合計時間を時間単位に変換します
+    total_duration_hours = total_duration_minutes / 60
+    # 合計時間（時間）と条件値を指定した比較演算子で比較します
+    return compare_values(total_duration_hours, condition_value, comparator)
 
 # ユーザーの累計日数を取得し、指定した条件値と比較する関数
 def check_total_days(user, condition_value, comparator):
@@ -33,15 +35,15 @@ def check_total_activities(user, condition_value, comparator):
 # ２つの値を比較し、true/falseの結果を返す関数
 def compare_values(actual_value, condition_value, comparator):
     if comparator == '<':
-        return condition_value < actual_value
+        return actual_value < condition_value
     elif comparator == '>':
-        return condition_value > actual_value
+        return actual_value > condition_value
     elif comparator == '<=':
-        return condition_value <= actual_value
+        return actual_value <= condition_value
     elif comparator == '>=':
-        return condition_value >= actual_value
+        return actual_value >= condition_value
     else:  # comparator == '=':
-        return condition_value == actual_value
+        return actual_value == condition_value
 
 
 # ActivityRecordが保存されるたびに呼び出され、バッジの獲得条件をチェックし、条件が満たされていればUserBadgeを生成する関数

--- a/django/static/admin/js/badge_list.js
+++ b/django/static/admin/js/badge_list.js
@@ -18,7 +18,7 @@ function static(path) {
    // データが存在しない場合のメッセージを表示
    if (data.length === 0) {
     const emptyMessage = document.createElement("p");
-    emptyMessage.textContent = "バッジがありません";
+    emptyMessage.textContent = "実績がありません";
     badgeList.appendChild(emptyMessage);
   } else {
     // データが存在する場合、それぞれのデータに対してチャットアイテムを作成し、追加する
@@ -41,13 +41,14 @@ function static(path) {
   if (badge.is_unlocked) {
     chatItem.style.backgroundColor = badge.color_code; // チャットの色を設定
 
-    const chatText = document.createTextNode(`${badge.date_unlocked}に${badge.badge_name}を獲得しました！`);
+    const chatText = document.createElement("span");
+    chatText.innerHTML = `実績:【${badge.badge_name}】を解除しました！<br>解除条件:${badge.badge_description}<br>解除日:${badge.date_unlocked}`;
     chatItem.appendChild(chatText);
   } else {
     chatItem.style.backgroundColor = "#A6A6A6"; // グレーの背景色
 
     const chatText = document.createElement("span");
-    chatText.innerHTML = `${badge.badge_name}は未獲得です。<br>獲得条件は${badge.badge_description}です。`;
+    chatText.innerHTML = `実績:【${badge.badge_name}】は未解除です。<br>解除条件:${badge.badge_description}`;
     chatItem.appendChild(chatText);
   }
 


### PR DESCRIPTION
## 目的
- 実績機能の修正
- 合わせて表示方法の修正

## 実装の概要/やったこと
- total_durationを分単位で計算していたのを時間単位で実績の判定をできるように修正
- comparator(比較演算子)を正しくなるように修正
- badgelistajaxview内の日付を渡す場所で日付を(YY/MM/DD)となるように変更
- badge_list.jsで、実績名をわかりやすいように【】で囲んだ
- badge_list.jsで、DBが「です。」などの文末を意識しなくて良いように変更

## 保留/やらないこと
- なし

## できるようになること（ユーザ目線）
- なし

## できなくなること（ユーザ目線）
- なし

## 動作確認
- ブラウザでの動作確認

## その他
- 演算子は完全に全部逆だったっぽいw
- 累計時間はDBに登録されている値が分単位なのに、adminで登録するのが時間単位だったことが原因でした。。
- ついでに表示も同じブランチで修正しました。
- 文末の「です。」を意識せずにDB登録をできるようにリスト表記っぽく変更しています。
- close #113 #110 
- @mappii130 
