### PR TITLE
[優先度高](ログイン画面)ログイン時のパスワードとメールアドレスの誤入力エラーが表示されない

### DIFF
--- a/django/templates/login.html
+++ b/django/templates/login.html
@@ -37,10 +37,12 @@
    <form method="POST">
     {% csrf_token %}
 
-    <!-- エラーメッセージの表示。-->
-    {% if form.is_bound %} {% if form.username.errors or form.password.errors %}
-    <div class="text-red-500 mb-4">メールアドレスまたはパスワードが正しくありません。</div>
-    {% endif %} {% endif %}
+    <!-- エラーメッセージの表示 -->
+    <div class="text-red-500 mb-4">
+      {% for error in form.non_field_errors %}
+        {{ error|escape }}
+      {% endfor %}
+    </div>
 
     <!-- メールアドレスの入力フィールド -->
     <div class="mb-4">
@@ -54,6 +56,12 @@
       class="mt-1 w-full px-4 py-2 border rounded-lg focus:outline-none focus:border-blue-500"
       value="{{ form.username.value|default:'' }}"
      />
+     <!-- エラーメッセージの表示 -->
+     {% for error in form.username.errors %}
+      <div class="text-red-500 mb-4">
+        {{ error|escape }}
+      </div>
+     {% endfor %}
     </div>
 
     <!-- パスワードの入力フィールド -->

--- a/django/users/forms.py
+++ b/django/users/forms.py
@@ -2,6 +2,9 @@ from django import forms
 from users.models import User
 from django.contrib.auth.password_validation import validate_password
 from django.contrib.auth.forms import AuthenticationForm
+from django.contrib.auth import authenticate
+from django.core.validators import validate_email
+from django.core.exceptions import ValidationError
 
 # ユーザー登録用
 class RegistForm(forms.ModelForm):
@@ -44,3 +47,19 @@ class RegistForm(forms.ModelForm):
 class UserLoginForm(AuthenticationForm):
     username = forms.EmailField(label='メールアドレス')
     password = forms.CharField(label='パスワード', widget=forms.PasswordInput())
+    error_messages = {
+        'invalid_login': "メールアドレスまたはパスワードが正しくありません。",
+    }
+
+    def clean(self):
+        cleaned_data = super().clean()
+        username = cleaned_data.get('username')
+        password = cleaned_data.get('password')
+
+        if username and password:
+            # ユーザー認証を行う
+            user = authenticate(username=username, password=password)
+            if user is None:
+                self.add_error(None, self.error_messages['invalid_login'])
+
+        return cleaned_data

--- a/django/users/forms.py
+++ b/django/users/forms.py
@@ -50,16 +50,3 @@ class UserLoginForm(AuthenticationForm):
     error_messages = {
         'invalid_login': "メールアドレスまたはパスワードが正しくありません。",
     }
-
-    def clean(self):
-        cleaned_data = super().clean()
-        username = cleaned_data.get('username')
-        password = cleaned_data.get('password')
-
-        if username and password:
-            # ユーザー認証を行う
-            user = authenticate(username=username, password=password)
-            if user is None:
-                self.add_error(None, self.error_messages['invalid_login'])
-
-        return cleaned_data


### PR DESCRIPTION
## 目的
-ログイン時のパスワードとメールアドレスの誤入力エラーが表示されない

## 実装の概要/やったこと

- UserLoginFormでloginできなかった際のエラー文を表示するように修正。
- メールアドレスが正しく入力されなかった際には、メールアドレスのフォームの下に表示するように修正

## 保留/やらないこと

- なし

## できるようになること（ユーザ目線）

- loginのメールアドレスとパスワードを間違ったことがエラー文で確認できる。

## できなくなること（ユーザ目線）

- なし

## 動作確認

- パスワードを間違えた場合、メールアドレスを間違えた場合、両方を間違えた場合とでエラーの表示内容を確認。

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #107 
- @dan-k4 
