### PR TITLE
(積み上げ記録一覧画面)積み上げ一覧の時間と日付の表示方法を変更

### DIFF
--- a/django/activity/views.py
+++ b/django/activity/views.py
@@ -199,11 +199,16 @@ class ActivityListAjaxView(LoginRequiredMixin, generic.View):
             else:
                 category_color = ''
 
+            # 時間のフォーマットを変更
+            hours = int(activity.duration / 60)
+            minutes = int(activity.duration % 60)
+            duration = f'{hours:02}:{minutes:02}'
+
             # 各アクティビティのデータをリストに追加
             activities_data.append({
                 'id': activity.pk,
-                'date': activity.date.strftime('%Y-%m-%d'),
-                'duration': round(activity.duration / 60, 1),
+                'date': activity.date.strftime('%Y/%m/%-d'),
+                'duration': duration,
                 'memo': activity.memo,
                 'category_color': category_color,
             })

--- a/django/static/admin/js/activity_list.js
+++ b/django/static/admin/js/activity_list.js
@@ -39,7 +39,18 @@ function createChatItem(record) {
  chatItem.classList.add("chat-bubble");
  chatItem.style.backgroundColor = record.category_color; // チャットの色を設定
 
-  const chatText = document.createTextNode(`${record.date}は${record.duration}時間頑張ったよ`);
+ const date = new Date(record.date);
+ const formattedDate = `${date.getFullYear()}/${date.getMonth() + 1}/${date.getDate()}`;
+ let formattedDuration = '';
+  const duration = record.duration.split(":").map(value => parseInt(value));
+  if (duration[0] > 0) {
+    formattedDuration += `${duration[0]}時間`;
+  }
+  if (duration[1] > 0 || duration[0] === 0) {
+    formattedDuration += `${duration[1]}分`;
+  }
+
+  const chatText = document.createTextNode(`${formattedDate}は${formattedDuration}頑張ったよ`);
   chatItem.appendChild(chatText);
 
   if (record.memo.length >= 0) {


### PR DESCRIPTION
## 目的
-積み上げ一覧の時間と日付の表示方法を変更

## 実装の概要/やったこと

- 積み上げ時間を〇時間〇分に
- 時間の登録で分がない場合は、〇時間にし、時間の登録がない場合は〇分となるように変更
- 日付をスラッシュで区切るように変更

## 保留/やらないこと

- なし

## できるようになること（ユーザ目線）

- 登録時間を分単位で確認できる

## できなくなること（ユーザ目線）

- なし

## 動作確認

- 表示されている時間と日付の確認

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #119 
- @dan-k4 
