### PR TITLE
[優先度高]（カテゴリー詳細画面）cart.js用の時間データを分単位から時間単位に変更

### DIFF
--- a/django/categories/views.py
+++ b/django/categories/views.py
@@ -10,6 +10,7 @@ from datetime import timedelta, datetime
 from activity.models import ActivityRecord
 from django.db.models import Sum, Value
 from django.db.models.functions import Coalesce
+from decimal import Decimal
 
 # Categoryの情報をJSON形式で返すView
 class CategoryHomeAjaxView(generic.View):
@@ -79,7 +80,8 @@ class CategoryDetailAjaxView(generic.DetailView):
         duration_list = []
         for date in dates:
             duration = activity_duration_dict.get(date, 0)
-            duration_list.append(duration)
+            duration_hours = Decimal(duration) / 60  # 分から0.0時間の単位に変換
+            duration_list.append(round(float(duration_hours), 1))  # 小数点第1位までに丸める
         category_data['duration_list'] = duration_list
 
         # カテゴリーの累計時間を計算


### PR DESCRIPTION
## 目的
-cart.js用の時間データを分単位から時間単位に変更

## 実装の概要/やったこと

- 時間データを分単位から時間単位（小数点第1位まで）に変更

## 保留/やらないこと

- なし

## できるようになること（ユーザ目線）

- 時間単位でのグラフが確認できる

## できなくなること（ユーザ目線）

- なし

## 動作確認

- <int:pk>/category_detail_ajax/でデータの値を確認

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #125 
- @dan-k4 
