### PR TITLE
‘ヘッダー/ハンバーガーメニューの文言修正、ファビコンの追加’

### DIFF
--- a/django/static/admin/js/existing_category.js
+++ b/django/static/admin/js/existing_category.js
@@ -1,0 +1,44 @@
+// HTMLのフォーム要素に"submit"イベントリスナーを追加します。フォームが送信されるときにこのリスナーが呼び出されます。
+document.getElementById("categoryEditForm").addEventListener("submit", function (event) {
+ // フォームの自動送信を防ぎます。これにより、非同期通信を行う前にフォームの送信を止めることができます。
+ event.preventDefault();
+
+ // フォームからカテゴリ名を取得します。
+ let categoryName = document.getElementsByName("name")[0].value;
+
+ // Djangoテンプレート変数から現在のオブジェクトIDを取得します。
+ let exclude_id = "{{ object.id }}";
+
+ // フォームデータを取得します。
+ let formData = new FormData(event.target);
+
+ // バックエンドサーバに非同期通信を行います。カテゴリ名と現在のオブジェクトIDを送信し、重複チェックを行います。
+ fetch("{% url 'categories:check_duplicate_edit' %}", {
+  method: "POST",
+  body: JSON.stringify({ name: categoryName, exclude_id: exclude_id }),
+  headers: {
+   "Content-Type": "application/json",
+   "X-CSRFToken": "{{ csrf_token }}"
+  }
+ })
+  // サーバからのレスポンスをJSONとして解析します。
+  .then(response => response.json())
+  .then(data => {
+   // サーバからのレスポンスに基づいて処理を行います。
+   if (data.duplicate) {
+    // 重複するカテゴリ名が存在する場合、警告メッセージを表示します。
+    document.getElementById("existingContainer").style.display = "block";
+    // 「新規カテゴリを作成」ボタンがクリックされた場合、フォームを送信します。
+    document.getElementById("createNewCategoryForExisting").onclick = function () {
+     event.target.submit();
+    };
+    // 「キャンセル」ボタンがクリックされた場合、警告メッセージを非表示にします。
+    document.getElementById("cancelNewCategoryForExisting").onclick = function () {
+     document.getElementById("existingContainer").style.display = "none";
+    };
+   } else {
+    // 重複するカテゴリ名が存在しない場合、フォームを送信します。
+    event.target.submit();
+   }
+  });
+});

--- a/django/templates/activity_add.html
+++ b/django/templates/activity_add.html
@@ -5,7 +5,7 @@ bg-snow text-textBlack font-NotoSans
 {% endblock body_class %}
 
 {% block title %}
-<title>アクティビティ追加</title>
+<title>積上記録</title>
 {% endblock %}
 
 {% load static %}
@@ -17,14 +17,14 @@ bg-snow text-textBlack font-NotoSans
   <nav class="text-lg">
    <a href="{% url 'activity:home' %}" class="hover:underline text-#474747">ホーム</a>
    <span> &gt; </span>
-   <span>積み上げ記録</span>
+   <span>積上記録</span>
   </nav>
  </div>
 
 
 <!-- タイトルの作成 -->
 <h1 class="container mx-auto px-4 pt-4 text-center bg-snow text-xl md:text-3xl text-textBlack">
-  積み上げを記録する 
+  積上記録 
  </h1>
  <hr class="mx-10 my-4 border-2 border-blackGreen shadow-md" />
 

--- a/django/templates/activity_list.html
+++ b/django/templates/activity_list.html
@@ -5,7 +5,7 @@ bg-snow text-textBlack font-NotoSans
 {% endblock body_class %}
 
 {% block title %}
-<title>アクティビティリスト</title>
+<title>積上一覧</title>
 {% endblock %}
 
 {% comment %} activity_list.js(レコード一覧チャット）に当てはめるためのcss {% endcomment %}
@@ -86,13 +86,13 @@ bg-snow text-textBlack font-NotoSans
   <nav class="text-lg">
    <a href="{% url 'activity:home' %}" class="hover:underline text-#474747">ホーム</a>
    <span> &gt; </span>
-   <span>積み上げ一覧</span>
+   <span>積上一覧</span>
   </nav>
  </div>
 
 <!-- タイトルの作成 -->
 <h1 class="container mx-auto px-4 pt-4 text-center bg-snow text-xl md:text-3xl text-textBlack">
-  積み上げ一覧
+  積上一覧
  </h1>
  <hr class="mx-10 my-4 border-2 border-blackGreen shadow-md" />
 

--- a/django/templates/badge_list.html
+++ b/django/templates/badge_list.html
@@ -5,7 +5,7 @@ bg-snow text-textBlack font-NotoSans
 {% endblock body_class %}
 
 {% block title %}
-    <title>Badge List</title>
+    <title>実績一覧</title>
 {% endblock %}
 
 {% comment %} badge_list.js(レコード一覧チャット）に当てはめるためのcss {% endcomment %}

--- a/django/templates/base.html
+++ b/django/templates/base.html
@@ -26,6 +26,10 @@
       rel="stylesheet"
     />
 
+    {% comment %} ファビコンの設定 {% endcomment %}
+    <link rel="icon" type="image/png" href="{% static 'admin/img/kotukotu_thumbnail.png' %}" />
+
+
     {% comment %} cdnで色をカスタムできないからhtmlのスタイルで当てる。importは最後の手段らしい。 {% endcomment %}
     <style>
         :root {
@@ -106,16 +110,16 @@
        <a href="{% url 'activity:home' %}" class="hover:underline">ホーム</a>
       </li>
       <li>
-       <a href="{% url 'activity:activity_list' %}" class="hover:underline">一覧</a>
+       <a href="{% url 'activity:activity_list' %}" class="hover:underline">積上一覧</a>
       </li>
       <li>
-       <a href="{% url 'activity:activity_add' %}" class="hover:underline">記録</a>
+       <a href="{% url 'activity:activity_add' %}" class="hover:underline">積上記録</a>
       </li>
       <li>
        <a href="{% url 'categories:category_add' %}" class="hover:underline">カテゴリー追加</a>
       </li>
       <li>
-       <a href="{% url 'badges:badge_list' %}" class="hover:underline">実績</a>
+       <a href="{% url 'badges:badge_list' %}" class="hover:underline">実績一覧</a>
       </li>
      </ul>
      <button
@@ -161,14 +165,17 @@
      <a href="{% url 'activity:home' %}" class="hover:underline">ホーム</a>
     </li>
     <li>
-     <a href="{% url 'activity:activity_list' %}" class="hover:underline">アクティビティ</a>
+     <a href="{% url 'activity:activity_list' %}" class="hover:underline">積上一覧</a>
     </li>
     <li>
-     <a href="{% url 'activity:activity_add' %}" class="hover:underline">記録画面</a>
+     <a href="{% url 'activity:activity_add' %}" class="hover:underline">積上記録</a>
     </li>
     <li>
      <a href="{% url 'categories:category_add' %}" class="hover:underline">カテゴリー追加</a>
     </li>
+    <li>
+      <a href="{% url 'badges:badge_list' %}" class="hover:underline">実績一覧</a>
+     </li>
     <li>
      <button
       type="submit"

--- a/django/templates/category_add.html
+++ b/django/templates/category_add.html
@@ -23,7 +23,7 @@ bg-snow text-textBlack font-NotoSans
 
 <!-- タイトルの作成 -->
 <h1 class="container mx-auto px-4 pt-4 text-center bg-snow text-xl md:text-3xl text-textBlack z-20">
-  カテゴリーを追加する
+  カテゴリー追加
  </h1>
  <hr class="mx-10 my-4 border-2 border-blackGreen shadow-md z-20" />
  

--- a/django/templates/login.html
+++ b/django/templates/login.html
@@ -18,6 +18,9 @@
    href="https://fonts.googleapis.com/css2?family=Noto+Emoji&family=Noto+Sans+JP:wght@100;200;300;400;500;600;700&display=swap"
    rel="stylesheet"
   />
+   {% comment %} ファビコンの設定 {% endcomment %}
+   <link rel="icon" type="image/png" href="{% static 'admin/img/kotukotu_thumbnail.png' %}" />
+
  </head>
 
  <body

--- a/django/templates/regist.html
+++ b/django/templates/regist.html
@@ -18,6 +18,9 @@
    href="https://fonts.googleapis.com/css2?family=Noto+Emoji&family=Noto+Sans+JP:wght@100;200;300;400;500;600;700&display=swap"
    rel="stylesheet"
   />
+   {% comment %} ファビコンの設定 {% endcomment %}
+   <link rel="icon" type="image/png" href="{% static 'admin/img/kotukotu_thumbnail.png' %}" />
+
  </head>
 
  <body

--- a/static/admin/js/categories_list.js
+++ b/static/admin/js/categories_list.js
@@ -1,0 +1,63 @@
+// テスト用のカテゴリデータの配列を定義
+const categories = [
+ {
+  categoryColor: "#DABEB7",
+  categoryName: "プログラミング",
+  categoryDuration: "00:30"
+ },
+ {
+  categoryColor: "#B7C1DA",
+  categoryName: "タイピング",
+  categoryDuration: "01:15"
+ },
+ {
+  categoryColor: "#DAD4B7",
+  categoryName: "英語",
+  categoryDuration: "00:45"
+ }
+];
+
+// HTMLのid属性が"category-list"の要素を取得
+const categoryList = document.getElementById("category-list");
+// 768px以下の画面幅用のcategory-list要素を取得
+const categoryListMobile = document.getElementById("category-list-mobile");
+
+// categories配列内の各要素に対して処理を実行
+categories.forEach(category => {
+ // 新しいdiv要素を作成
+ const categoryElement = document.createElement("div");
+ // 作成したdiv要素にCSSクラスを設定
+ categoryElement.className =
+  "bg-[COLOR] text-textBlack rounded-lg p-4 w-64 h-12 flex justify-between items-center mb-4";
+ // 作成したdiv要素の背景色を設定
+ categoryElement.style.backgroundColor = category.categoryColor;
+
+ // 新しいspan要素を作成
+ const categoryName = document.createElement("span");
+ // 作成したspan要素にCSSクラスを設定
+ categoryName.className = "category-name";
+ // 作成したspan要素にテキストコンテンツを設定
+ categoryName.textContent = category.categoryName;
+ // div要素にspan要素を追加（カテゴリ名を表示）
+ categoryElement.appendChild(categoryName);
+
+ // 新しいspan要素を作成
+ const categoryDuration = document.createElement("span");
+ // 作成したspan要素にCSSクラスを設定
+ categoryDuration.className = "category-duration";
+ // 作成したspan要素にテキストコンテンツを設定（累計時間を表示）
+ categoryDuration.textContent = `累計時間 ${category.categoryDuration}`;
+ // div要素にspan要素を追加（累計時間を表示）
+ categoryElement.appendChild(categoryDuration);
+
+ // categoryList要素に作成したdiv要素を追加
+ categoryList.appendChild(categoryElement);
+
+ // 768px以下の画面幅用に要素を複製
+ const categoryElementMobile = categoryElement.cloneNode(true);
+ // 作成したdiv要素にCSSクラスを設定
+ categoryElementMobile.className =
+  "bg-[COLOR] text-textBlack rounded-lg p-2 mx-auto w-full h-12 flex justify-between items-center mb-4 mx-8";
+ // categoryListMobile要素に作成したdiv要素
+ categoryListMobile.appendChild(categoryElementMobile);
+});

--- a/static/admin/js/categories_list.js
+++ b/static/admin/js/categories_list.js
@@ -1,21 +1,21 @@
 // テスト用のカテゴリデータの配列を定義
-const categories = [
- {
-  categoryColor: "#DABEB7",
-  categoryName: "プログラミング",
-  categoryDuration: "00:30"
- },
- {
-  categoryColor: "#B7C1DA",
-  categoryName: "タイピング",
-  categoryDuration: "01:15"
- },
- {
-  categoryColor: "#DAD4B7",
-  categoryName: "英語",
-  categoryDuration: "00:45"
- }
-];
+// const categories = [
+//  {
+//   categoryColor: "#DABEB7",
+//   categoryName: "プログラミング",
+//   categoryDuration: "00:30"
+//  },
+//  {
+//   categoryColor: "#B7C1DA",
+//   categoryName: "タイピング",
+//   categoryDuration: "01:15"
+//  },
+//  {
+//   categoryColor: "#DAD4B7",
+//   categoryName: "英語",
+//   categoryDuration: "00:45"
+//  }
+// ];
 
 // HTMLのid属性が"category-list"の要素を取得
 const categoryList = document.getElementById("category-list");


### PR DESCRIPTION
## 目的
-全ページのヘッダーなどの文言をユーザー目線に統一。ファビコンの追加。

## 実装の概要/やったこと

- 各ページの文言の整理。base.htmlの文言整理。base.htmlにファビコン追加。login、registにファビコンの追加。

## 保留/やらないこと

なし

## できるようになること（ユーザ目線）

- 回遊が容易になりました。ファビコンが表示されるようになりました。

## できなくなること（ユーザ目線）

- なし

## 動作確認

- ローカルホストでの確認を行いました。

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #108 #127 
- @hiroki-rr 
