### PR TITLE
カテゴリー編集ページの色の選択の入力を削除、色枠を追加

### DIFF
--- a/django/static/admin/js/category_add.js
+++ b/django/static/admin/js/category_add.js
@@ -35,3 +35,25 @@ function handleButtonClick(event) {
     // クリックしたボタンにボーダーを追加
     event.target.style.border = '5px solid white';
   }
+
+  // 色をもう一度押すと白枠が消える　要らなさそうなのでコメントアウトして一応残します。5/25
+
+  // function handleButtonClick(event) {
+  //   // すべてのボタンからボーダーを削除
+  //   let buttons = document.querySelectorAll('.color-button');
+  //   // 既にボーダーがあるかを判定する
+  //   let isBorder = false;
+  //   if (event.target.style.border) {
+  //     isBorder = true;
+  //   }
+  //   for (let i = 0; i < buttons.length; i++) {
+  //     buttons[i].style.border = '';
+  //   }
+       // ボーダーがあれば解除、なければ指定
+  //   if (isBorder) {
+  //     event.target.style.border = '';
+  //   } else {
+  //     // クリックしたボタンにボーダーを追加
+  //     event.target.style.border = '5px solid white';
+  //   }
+  // }

--- a/django/templates/category_edit.html
+++ b/django/templates/category_edit.html
@@ -42,23 +42,30 @@ bg-snow text-textBlack font-NotoSans
      {{ form.goal }}
    </div>
 
-   <!-- カラーの選択 -->
    <div class="mx-auto w-full md:w-3/4 py-2 bg-blackGreen text-textBlack rounded-lg flex items-center justify-center">
-     {{ form.color_code.label_tag }}
-     {{ form.color_code }}
-   </div>
+    <div style="display: flex; align-items: center; justify-content: center; width: 100%;">
+      <label for="id_color_code" class="pr-2">Color:</label> <!-- margin-rightを削除し、justify-content: center;を追加 -->
+      <div class="color-sample">
+        <div id="color-circle" style="width: 160px; height: 25px;"></div> <!-- border-radiusを削除して四角形にする -->
+      </div>
+    </div>
+    <div style="display: none;">
+      {{ form.color_code.label_tag }}
+      {{ form.color_code }}
+    </div>
+  </div>  
 
 
         <!-- 色の選択。押したらクリップボードにコピーされる -->
-      <div class="flex flex-wrap justify-center space-x-4">
-        <div class="w-16 h-16 md:w-16 md:h-16 bg-[#DAD4B7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#DAD4B7')">#DAD4B7</div>
-        <div class="w-16 h-16 md:w-16 md:h-16 bg-[#B7C1DA] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#B7C1DA')">#B7C1DA</div>
-        <div class="w-16 h-16 md:w-16 md:h-16 bg-[#DABEB7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#DABEB7')">#DABEB7</div>
-        <div class="w-16 h-16 md:w-16 md:h-16 bg-[#DAC6B7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#DAC6B7')">#DAC6B7</div>
-        <div class="w-16 h-16 md:w-16 md:h-16 bg-[#CFB7DA] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#CFB7DA')">#CFB7DA</div>
-        <div class="w-16 h-16 md:w-16 md:h-16 bg-[#B7D6DA] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#B7D6DA')">#B7D6DA</div>
-        <div class="w-16 h-16 md:w-16 md:h-16 bg-[#C6DAB7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs" onclick="copyToClipboard('#C6DAB7')">#C6DAB7</div>
-      </div>
+        <div class="flex flex-wrap justify-center space-x-4">
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#DAD4B7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs color-button" onclick="copyToClipboard('#DAD4B7'); handleButtonClick(event)"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#B7C1DA] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs color-button" onclick="copyToClipboard('#B7C1DA'); handleButtonClick(event)"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#DABEB7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs color-button" onclick="copyToClipboard('#DABEB7'); handleButtonClick(event)"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#DAC6B7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs color-button" onclick="copyToClipboard('#DAC6B7'); handleButtonClick(event)"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#CFB7DA] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs color-button" onclick="copyToClipboard('#CFB7DA'); handleButtonClick(event)"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#B7D6DA] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs color-button" onclick="copyToClipboard('#B7D6DA'); handleButtonClick(event)"></div>
+          <div class="w-16 h-16 md:w-16 md:h-16 bg-[#C6DAB7] rounded text-center line-height[6rem] md:line-height[4rem] cursor-pointer text-base md:text-xs color-button" onclick="copyToClipboard('#C6DAB7'); handleButtonClick(event)"></div>
+        </div>
 
 
 


### PR DESCRIPTION
## 目的
- カテゴリー編集ページの色の選択の入力を削除、色枠を追加

## 実装の概要/やったこと

- カテゴリー編集ページでも追加と同じように入力を削除、色がわかりやすく入力欄だったところに追加

## 保留/やらないこと

- なしです

## できるようになること（ユーザ目線）

- カテゴリの編集でも何色を選択したかがわかりやすくなる。

## できなくなること（ユーザ目線）

- カテゴリの編集で色を自由に入力すること

## 動作確認

- ローカルで確認。

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #111 
- @hosomatu 

よろしくお願いします！