### PR TITLE
カテゴリー追加と編集ページで同カテゴリ名の確認モーダルに<br>で改行を追加

### DIFF
--- a/django/templates/category_add.html
+++ b/django/templates/category_add.html
@@ -113,7 +113,7 @@ bg-snow text-textBlack font-NotoSans
 <div id="existingContainer" style="display:none" class="fixed top-0 left-0 w-full h-full bg-black bg-opacity-50 z-50">
   <!-- モーダルの背景（見えてる部分） -->
   <div class="bg-white w-11/12 h-1/3 md:max-w-md mx-auto rounded shadow-lg p-6 mt-20 relative">
-   <p class="text-center mt-8">既に同じ名前のカテゴリーが存在するようです。カテゴリーを作成しますか？</p>
+   <p class="text-center mt-8">既に同じ名前のカテゴリーが存在するようです。<br>カテゴリーを作成しますか？</p>
    <div class="flex justify-center mt-8 space-x-4">
     {% comment %} 書くボタンにバックエンドに合わせてidを足した。 {% endcomment %}
     <button class="bg-orangerange text-white px-4 py-2 rounded" id="createNewCategoryForExisting">はい</button>

--- a/django/templates/category_edit.html
+++ b/django/templates/category_edit.html
@@ -74,7 +74,7 @@ bg-snow text-textBlack font-NotoSans
 <div id="existingContainer" style="display:none" class="fixed top-0 left-0 w-full h-full bg-black bg-opacity-50 z-50">
   <!-- モーダルの背景（見えてる部分） -->
   <div class="bg-white w-11/12 h-1/3 md:max-w-md mx-auto rounded shadow-lg p-6 mt-20 relative">
-   <p class="text-center mt-8">既に同じ名前のカテゴリーが存在するようです。カテゴリーを編集しますか？</p>
+   <p class="text-center mt-8">既に同じ名前のカテゴリーが存在するようです。<br>カテゴリーを編集しますか？</p>
    <div class="flex justify-center mt-8 space-x-4">
     {% comment %} 書くボタンにバックエンドに合わせてidを足した。 {% endcomment %}
     <button class="bg-orangerange text-white px-4 py-2 rounded" id="createNewCategoryForExisting">はい</button>


### PR DESCRIPTION
## 目的
- カテゴリー追加と編集ページで同カテゴリ名の確認を見やすく

## 実装の概要/やったこと

- カテゴリー追加と編集ページで同カテゴリ名の確認モーダルに<br>で改行を追加

## 保留/やらないこと

- なし

## できるようになること（ユーザ目線）

- 見やすい

## できなくなること（ユーザ目線）

- なし

## 動作確認

- ローカルで確認

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #116 
- @hosomatu 
