### PR TITLE
‘積み上げ一覧の調整’

### DIFF
--- a/django/templates/activity_list.html
+++ b/django/templates/activity_list.html
@@ -36,6 +36,11 @@ bg-snow text-textBlack font-NotoSans
     gap: 10px; /* アイテム間のスペースを調整する */
   }
 
+  .text-container {
+    max-width: 80%;  
+    white-space: normal;
+  }
+  
   .chat-bubble:before {
     content: "";
     position: absolute;
@@ -61,8 +66,10 @@ bg-snow text-textBlack font-NotoSans
   }
 
   .trash-icon {
-    width: 20px;
-    height: 20px;
+    width: 20px !important;
+    height: 20px !important;
+    min-width: 10px !important;
+    min-height: 10px !important;
   }
 
   .chat-icon {


### PR DESCRIPTION
## 目的
-積み上げ一覧でゴミ箱や編集ボタンが崩れるのを防ぐ

## 実装の概要/やったこと

- 画面幅に合わせてメモが改行されるようにしました。

## 保留/やらないこと

- カテゴリー名を追加する方法がわかりませんでしたので実施していないです。

## できるようになること（ユーザ目線）

- 画面サイズに合わせて表示できるようになりました。

## できなくなること（ユーザ目線）

-とくになし

## 動作確認

- ローカルホストで実行しました。

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #114 
- @hiroki-rr 
