### PR TITLE
(実績一覧画面)獲得までに必要な残りの条件を表示する

### DIFF
--- a/django/badges/views.py
+++ b/django/badges/views.py
@@ -12,17 +12,25 @@ from django.http import JsonResponse
 def check_total_duration(user, condition_value, comparator):
     # ユーザーの全ての活動レコードから累計時間（分）を合計します
     total_duration_minutes = ActivityRecord.objects.filter(user=user).aggregate(Sum('duration'))['duration__sum']
+    if total_duration_minutes is None:
+        total_duration_minutes = 0
     # 合計時間を時間単位に変換します
     total_duration_hours = total_duration_minutes / 60
     # 合計時間（時間）と条件値を指定した比較演算子で比較します
-    return compare_values(total_duration_hours, condition_value, comparator)
+    countdown_value = condition_value - total_duration_hours
+    if countdown_value <= 0:
+        return 0
+    return countdown_value
 
 # ユーザーの累計日数を取得し、指定した条件値と比較する関数
 def check_total_days(user, condition_value, comparator):
     # ユーザーの全ての活動レコードから日付を一意に数え上げます
     total_days = ActivityRecord.objects.filter(user=user).dates('date', 'day').count()
     # 合計日数と条件値を指定した比較演算子で比較します
-    return compare_values(total_days, condition_value, comparator)
+    countdown_value = condition_value - total_days
+    if countdown_value <= 0:
+        return 0
+    return countdown_value
 
 
 # ユーザーの累計活動数を取得し、指定した条件値と比較する関数
@@ -30,7 +38,10 @@ def check_total_activities(user, condition_value, comparator):
     # ユーザーの全ての活動レコードの数を数え上げます
     total_activities = ActivityRecord.objects.filter(user=user).count()
     # 合計活動数と条件値を指定した比較演算子で比較します
-    return compare_values(total_activities, condition_value, comparator)
+    countdown_value = condition_value - total_activities
+    if countdown_value <= 0:
+        return 0
+    return countdown_value
 
 # ２つの値を比較し、true/falseの結果を返す関数
 def compare_values(actual_value, condition_value, comparator):
@@ -68,7 +79,7 @@ def check_badges(sender, instance, **kwargs):
             result = check_total_activities(user, badge.condition_value, badge.comparator)
 
         # 実績が達成されている場合は、ユーザーのバッジを更新
-        if result:
+        if not result:
             UserBadge.objects.create(user=user, badge=badge)
 
 
@@ -96,7 +107,8 @@ class BadgeListAjaxView(LoginRequiredMixin, generic.View):
                 "badge_type": ub.badge.badge_type,
                 "color_code": BadgeType.objects.get(badge_type=ub.badge.badge_type).color_code,
                 "is_unlocked": True,  # ユーザーが獲得したため、is_unlockedはTrueです。
-                "date_unlocked": ub.date_unlocked.strftime('%Y/%-m/%-d')  # 獲得した日付
+                "date_unlocked": ub.date_unlocked.strftime('%Y/%-m/%-d'),  # 獲得した日付
+                "countdown_text": None  # 初期値としてNoneを設定
                 }
             for ub in user_badges
         ]
@@ -106,6 +118,26 @@ class BadgeListAjaxView(LoginRequiredMixin, generic.View):
         for badge in all_badges:
             # もしバッジがまだ獲得されていなければ
             if not any(d['badge_name'] == badge.name for d in data):
+                # 実績の条件に応じた関数を呼び出す
+                if badge.condition_type == 'total_duration':
+                    countdown_value = check_total_duration(user, badge.condition_value, badge.comparator)
+                    hours = int(countdown_value)
+                    minutes = int((countdown_value - hours) * 60)
+
+                    if hours == 0:
+                        countdown_text = f"{minutes}分"
+                    elif minutes == 0:
+                        countdown_text = f"{hours}時間"
+                    else:
+                        countdown_text = f"{hours}時間{minutes}分"
+
+                elif badge.condition_type == 'total_days':
+                    countdown_value = check_total_days(user, badge.condition_value, badge.comparator)
+                    countdown_text = f"{countdown_value} 日"
+                else:  # badge.condition_type == 'total_activities':
+                    countdown_value = check_total_activities(user, badge.condition_value, badge.comparator)
+                    countdown_text = f"{countdown_value} 回"
+
                 # データに追加します。
                 data.append({
                     "badge_id": badge.pk,
@@ -115,6 +147,7 @@ class BadgeListAjaxView(LoginRequiredMixin, generic.View):
                     "color_code": BadgeType.objects.get(badge_type=badge.badge_type).color_code,
                     "is_unlocked": False,  # 未獲得のため、is_unlockedはFalseです。
                     "date_unlocked": None,  # 未獲得のため、date_unlockedはNoneです。
+                    "countdown_text": countdown_text # カウントダウンの値を追加
                 })
         # JSON形式でデータを返します。
         return JsonResponse(data, safe=False)

--- a/django/static/admin/js/badge_list.js
+++ b/django/static/admin/js/badge_list.js
@@ -49,7 +49,7 @@ function static(path) {
     chatItem.style.color = "white"; // 文字色を白に設定
 
     const chatText = document.createElement("span");
-    chatText.innerHTML = `実績:【${badge.badge_name}】は未解除です。<br>解除条件:${badge.badge_description}`;
+    chatText.innerHTML = `実績:【${badge.badge_name}】は未解除です。<br>解除条件:${badge.badge_description}<br>解除まで残り:${badge.countdown_text}`;
     chatItem.appendChild(chatText);
 
   }


### PR DESCRIPTION
## 目的
-(実績一覧画面)獲得までに必要な残りの条件を表示する

## 実装の概要/やったこと

- カウントダウンで残りの日数や回数、時間を実績一覧画面で表示できるように修正

## 保留/やらないこと

- なし

## できるようになること（ユーザ目線）

- 獲得までに記録がどのくらい必要かがわかる

## できなくなること（ユーザ目線）

- なし

## 動作確認

- 獲得までの計算が間違っていないか
- ちゃんとバッジを獲得することができるか

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #71 
- @dan-k4 
